### PR TITLE
Use Mockito to mock AWS in unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,5 +74,11 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/gov/nasa/cumulus/SNSSender.java
+++ b/src/main/java/gov/nasa/cumulus/SNSSender.java
@@ -14,8 +14,12 @@ public class SNSSender extends Sender {
     private AmazonSNS snsClient;
 
     public SNSSender(String region) {
+        this(region, AmazonSNSClientBuilder.standard().withRegion(region).build());
+    }
+
+    public SNSSender(String region, AmazonSNS snsClient) {
         super(region);
-        this.snsClient = AmazonSNSClientBuilder.standard().withRegion(region).build();
+        this.snsClient = snsClient;
     }
 
     /**


### PR DESCRIPTION
Add Mockito 3.6.0 as a dependency, for test scope only.
Use Mockito to remove the dependency on AWS in unit tests.