### PR TITLE
Feature/podaac 2552

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CNM schema change which requires CNM-R to include product object.
 - **PODAAC-2551**
   - a build script under /builder directory, and a jenkins job to build and push release to public github.
-  
+- **PODAAC-2552**
+  - catch (reasonable) exceptions, and ensure we send an SNS failure message, before re-throwing the exception.
+    
 ### Changed
 - **PODAAC-2641**
   - Added UTC timezone to processCompleteTime.

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -58,11 +58,11 @@ public class CNMResponse implements  ITask, RequestHandler<String, String>{
 	public static JsonObject getResponseObject(String exception) {
 		JsonObject response = new JsonObject();
 
-		if(exception == null || new String("").equals(exception) ||  new String("None").equals(exception) ||  new String("\"None\"").equals(exception)){
-			//success
+        if (exception == null || exception.isEmpty() || exception.equals("None") || exception.equals("\"None\"")) {
+            //success
 			AdapterLogger.LogInfo(CNMResponse.class.getName() + " status: SUCCESS");
 			response.addProperty("status", "SUCCESS");
-		}else{
+		} else {
 			//fail
 			AdapterLogger.LogWarning(CNMResponse.class.getName() + " status: FAILURE");
 			response.addProperty("status", "FAILURE");

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -102,12 +102,12 @@ public class AppTest
         try {
             sender.sendMessage("testMessage", "badTopic");
     		fail("Should have failed with invalid topic");
-    	}catch(Exception e){}
+    	} catch (Exception e) {}
 
         // finally, test with our valid topic
         try {
             sender.sendMessage("testMessage", topicARN);
-        } catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             fail("Should not have failed with valid topic");
         }
@@ -172,6 +172,36 @@ public class AppTest
 		assertEquals(CNMResponse.ErrorCode.VALIDATION_ERROR.toString(), responseUnexpectedFileSize.get("errorCode").getAsString());
 		assertEquals("Placeholder for UnexpectedFileSize message", responseUnexpectedFileSize.get("errorMessage").getAsString());
 	}
+
+    public void testGeneralFailureMessage() throws Exception {
+
+        StringBuilder sb = new StringBuilder();
+        Scanner scanner  =
+                new Scanner(new File(getClass().getClassLoader().getResource("workflow.success.json").getFile()));
+        //String text = new Scanner(ClassLoader.getSystemResource("workflow.error.json")).useDelimiter("\\A").next();
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            sb.append(line).append("\n");
+        }
+
+        scanner.close();
+        String text = sb.toString();
+        System.out.println("Processing " + text);
+
+        JsonElement jelement = new JsonParser().parse(text);
+        JsonObject inputKey = jelement.getAsJsonObject();
+
+        JsonObject  inputConfig = inputKey.getAsJsonObject("config");
+
+        CNMResponse cnm = new CNMResponse();
+        String output = CNMResponse.generateGeneralError(new Gson().toJson(inputConfig.get("OriginalCNM")));
+        JsonElement outputElement = new JsonParser().parse(output);
+        JsonObject response = outputElement.getAsJsonObject().get("response").getAsJsonObject();
+        JsonElement product = outputElement.getAsJsonObject().get("product");
+        assertNotSame("SUCCESS", response.get("status").getAsString());
+        assertEquals("FAILURE", response.get("status").getAsString());
+        assertEquals(product, null);
+    }
 
 	/**
 	 * Test success CNM response


### PR DESCRIPTION
Intercept general exceptions being thrown while parsing the CNM messages, and ensure we send SNS failure messages, before re-throwing the exception.