### PR TITLE
Feature/podaac 2552

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- **PODAAC-2552**
+  - Catch exceptions during 'handleRequest' and 'handleRequestStreams' and always send a failure response message, before re-throwing the exception.
 ### Security
 - **Snyk**
   - Upgrade com.amazonaws:aws-java-sdk-core:1.11.660 -> 1.11.903

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- **PODAAC-2552**
+    - Catch exceptions during 'PerformFunction' and always send a failure response message, before re-throwing the 
+      exception.
+### Security
+    
 # [v1.2.0] - 2020-12-15
 ### Added
 - **PODAAC-2783**
@@ -16,8 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- **PODAAC-2552**
-  - Catch exceptions during 'handleRequest' and 'handleRequestStreams' and always send a failure response message, before re-throwing the exception.
 ### Security
 - **Snyk**
   - Upgrade com.amazonaws:aws-java-sdk-core:1.11.660 -> 1.11.903

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -267,7 +267,7 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
                     .getAsJsonObject("OriginalCNM")
                     .get("collection").getAsString();
         } catch (Exception e) {
-            if (input.has("collection")) {
+            if (input.getAsJsonObject("input").has("collection")) {
                 return input.getAsJsonObject("collection").getAsString();
             } else {
                 return "Unknown/Missing";

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -233,8 +233,8 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      * Gets the value for the 'DataVersion' field, to be used
      * by the 'buildMessageAttributesHash' method.
      * <br><br>
-     * Tries to use the OriginalCNM > Product > DataVersion from the
-     * input > config section, of the provided Json, but in case of an error,
+     * Tries to use the 'OriginalCNM > Product > DataVersion' from the
+     * 'input > config' section, of the provided Json, but in case of an error,
      * return a generic error string.
      *<br><br>
      * @param input     the input > config section, as a JsonObject
@@ -254,9 +254,9 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      * Gets the value for the 'collection' field, to be used
      * by the 'buildMessageAttributesHash' method.
      * <br><br>
-     * First to use the OriginalCNM > collection
+     * First try to use the OriginalCNM > collection field
      * Next checks input > collection
-     * If neither is available, the returns a generic error string
+     * If neither is available, then returns a generic error string
      *<br><br>
      * @param input     the raw input to PerformFunction, as JsonObject
      * @return          the string to use as the 'collection' value
@@ -301,7 +301,7 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      * using the 'response > status' field from the 'output'
      * along with the provided values for 'collection' and 'dataversion'
      * <br><br>
-     * @param output        the final output message, as String
+     * @param output        the final output json message, as String
      * @param method        the method to use, 'Kinesis' or 'Sns' when sending
      * @param region        the region to send the message to
      * @param endpoint      the actual endpoint for the message

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -178,6 +178,32 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         return exception;
     }
 
+    public static String generateGeneralError(String input) {
+        JsonElement jelement = new JsonParser().parse(input);
+        JsonObject inputKey = jelement.getAsJsonObject();
+        JsonObject response = getResponseObject("CNMResponse Exception");
+        // remove the product information
+        inputKey.remove("product");
+        inputKey.add("response", response);
+        // add the completion timestamp
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        df.setTimeZone(tz);
+        String nowAsISO = df.format(new Date());
+        inputKey.addProperty("processCompleteTime", nowAsISO);
+        return new Gson().toJson(inputKey);
+    }
+
+    public static void sendSNS(String output, String method, String region, JsonElement endPoint) {
+        if (method != null) {
+            if (endPoint.isJsonArray()) {
+                SenderFactory.getSender(region, method).sendMessage(output, endPoint.getAsJsonArray());
+            } else {
+                SenderFactory.getSender(region, method).sendMessage(output, endPoint.getAsString());
+            }
+        }
+    }
+
     //inputs
     // OriginalCNM
     // CNMResponseStream

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -156,13 +156,19 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         // but the FAILURE case, response does not include cmr data
         inputKey.add("response", response);
 
+        inputKey.addProperty("processCompleteTime", CNMResponse.getCompletionTimestamp());
+        return new Gson().toJson(inputKey);
+    }
+
+    /**
+     * Builds the completion timestamp using the current Time
+     * @return      the timestamp, properly formatted, as string
+     */
+    public static String getCompletionTimestamp() {
         TimeZone tz = TimeZone.getTimeZone("UTC");
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         df.setTimeZone(tz);
-        String nowAsISO = df.format(new Date());
-
-        inputKey.addProperty("processCompleteTime", nowAsISO);
-        return new Gson().toJson(inputKey);
+        return df.format(new Date());
     }
 
     public String getError(JsonObject input, String key) {
@@ -219,11 +225,7 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         response.addProperty("errorMessage", cause);
         failureJson.add("response", response);
         // add the completion timestamp
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        df.setTimeZone(tz);
-        String nowAsISO = df.format(new Date());
-        failureJson.addProperty("processCompleteTime", nowAsISO);
+        failureJson.addProperty("processCompleteTime", CNMResponse.getCompletionTimestamp());
         return new Gson().toJson(failureJson);
     }
 

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -268,7 +268,7 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
                     .get("collection").getAsString();
         } catch (Exception e) {
             if (input.getAsJsonObject("input").has("collection")) {
-                return input.getAsJsonObject("collection").getAsString();
+                return input.getAsJsonObject("input").get("collection").getAsString();
             } else {
                 return "Unknown/Missing";
             }

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -2,6 +2,7 @@ package gov.nasa.cumulus;
 
 import com.amazonaws.services.sns.model.NotFoundException;
 import com.google.gson.*;
+import cumulus_message_adapter.message_parser.MessageAdapterException;
 import gov.nasa.cumulus.bo.MessageAttribute;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -174,6 +175,43 @@ public class AppTest
 		assertEquals(CNMResponse.ErrorCode.VALIDATION_ERROR.toString(), responseUnexpectedFileSize.get("errorCode").getAsString());
 		assertEquals("Placeholder for UnexpectedFileSize message", responseUnexpectedFileSize.get("errorMessage").getAsString());
 	}
+
+	public void testGeneralFailure() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        CNMResponse cnmResponse = new CNMResponse();
+        File inputJsonFile = new File(classLoader.getResource("workflow.granulefailure.json").getFile());
+
+        String input = "";
+        try {
+            input = new String(Files.readAllBytes(inputJsonFile.toPath()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        JsonElement jelement = new JsonParser().parse(input);
+        JsonObject inputKey = jelement.getAsJsonObject();
+        MessageAdapterException ex = new MessageAdapterException("Test exception.");
+        String output = cnmResponse.generateGeneralError(inputKey, ex.getMessage());
+        JsonElement outputElement = new JsonParser().parse(output);
+        JsonObject outputJson = outputElement.getAsJsonObject();
+        // check that we have the minimun acceptable json according to the schema
+        String[] schemaFields = {"version", "provider", "collection", "submissionTime", "receivedTime", "identifier",
+                "response"};
+        for (String field : schemaFields) {
+            assertTrue(outputJson.has(field));
+        }
+        // now check all  the top level elements are included, and correct
+        assertEquals("L0A_KCAL_Packet", outputJson.get("collection").getAsString());
+        assertEquals("1.0", outputJson.get("version").getAsString());
+        assertEquals("PODAAC", outputJson.get("provider").getAsString());
+        assertEquals("2020-07-05T20:42:32.682418", outputJson.get("submissionTime").getAsString());
+        assertEquals("PODAAC", outputJson.get("provider").getAsString());
+        // now check the response section
+        JsonObject response = outputElement.getAsJsonObject().get("response").getAsJsonObject();
+        assertEquals("FAILURE", response.get("status").getAsString());
+        assertEquals("PROCESSING_ERROR", response.get("errorCode").getAsString());
+        assertNotNull(response.get("errorMessage").getAsString());
+    }
 
 	/**
 	 * Test success CNM response

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -191,10 +191,10 @@ public class AppTest
         JsonElement jelement = new JsonParser().parse(input);
         JsonObject inputKey = jelement.getAsJsonObject();
         MessageAdapterException ex = new MessageAdapterException("Test exception.");
-        String output = cnmResponse.generateGeneralError(inputKey, ex.getMessage());
+        String output = cnmResponse.buildGeneralError(inputKey, ex.getMessage());
         JsonElement outputElement = new JsonParser().parse(output);
         JsonObject outputJson = outputElement.getAsJsonObject();
-        // check that we have the minimun acceptable json according to the schema
+        // check that we have the minimum acceptable json according to the schema
         String[] schemaFields = {"version", "provider", "collection", "submissionTime", "receivedTime", "identifier",
                 "response"};
         for (String field : schemaFields) {

--- a/src/test/resources/workflow.granulefailure.json
+++ b/src/test/resources/workflow.granulefailure.json
@@ -1,0 +1,35 @@
+{
+  "input": {
+    "collection": "L0A_KCAL_Packet",
+    "version": "1.0",
+    "provider": "PODAAC",
+    "submissionTime": "2020-07-05T20:42:32.682418",
+    "identifier": "45150e51-955a-11ea-80e5-acde48001122"
+  },
+  "config": {
+    "OriginalCNM": null,
+    "type": "sns",
+    "response-endpoint": "arn:aws:sns:us-west-2:111111111111:podaac-sndbx-cumulus-provider-response-sns",
+    "region": "us-west-2",
+    "WorkflowException": {
+      "Error": "cumulus_message_adapter.message_parser.MessageAdapterException",
+      "Cause": "{\\\"errorMessage\\\":\\\"An error occurred in the Cumulus Message Adapter: java.lang.NullPointerException\\\",\\\"errorType\\\":\\\"cumulus_message_adapter.message_parser.MessageAdapterException\\\",\\\"stackTrace\\\":[\\\"cumulus_message_adapter.message_parser.MessageParser.HandleMessage(MessageParser.java:100)\\\",\\\"cumulus_message_adapter.message_parser.MessageParser.RunCumulusTask(MessageParser.java:117)\\\",\\\"gov.nasa.cumulus.CnmToGranuleHandler.handleRequestStreams(CnmToGranuleHandler.java:55)\\\",\\\"sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\\\",\\\"sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\\",\\\"sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\\",\\\"java.lang.reflect.Method.invoke(Method.java:498)\\\"],\\\"cause\\\":{\\\"errorMessage\\\":\\\"java.lang.NullPointerException\\\",\\\"errorType\\\":\\\"java.lang.NullPointerException\\\",\\\"stackTrace\\\":[\\\"gov.nasa.cumulus.CnmToGranuleHandler.PerformFunction(CnmToGranuleHandler.java:126)\\\",\\\"cumulus_message_adapter.message_parser.MessageParser.HandleMessage(MessageParser.java:76)\\\",\\\"cumulus_message_adapter.message_parser.MessageParser.RunCumulusTask(MessageParser.java:117)\\\",\\\"gov.nasa.cumulus.CnmToGranuleHandler.handleRequestStreams(CnmToGranuleHandler.java:55)\\\",\\\"sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\\\",\\\"sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\\",\\\"sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\\",\\\"java.lang.reflect.Method.invoke(Method.java:498)\\\"]}}"
+    }
+  },
+  "messageConfig": {
+    "outputs": [
+      {
+        "source": "{$.cnm}",
+        "destination": "{$.meta.cnmResponse}"
+      },
+      {
+        "source": "{$.input.input}",
+        "destination": "{$.payload}"
+      }
+    ]
+  },
+  "cumulus_config": {
+    "state_machine": "arn:aws:states:us-west-2:111111111111:stateMachine:podaac-sndbx-cumulus-IngestWorkflow",
+    "execution_name": "d0473918-e64c-4bf5-82fc-5c4e4bcb3e2b"
+  }
+}


### PR DESCRIPTION
Fix for no failure messages being sent when encountering exceptions during PerformFunction.

This change makes sure we catch all exceptions and send the minimum acceptable (per the message schema) failure message, before re-throwing the exception.