### PR TITLE
PCESA-2418 Updated CNMResponse task to not require cmrConceptId and cmrLink in granule input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [v1.4.0] - 2021-05-06
+### Added
+### Changed
+- **PCESA-2418**
+    - Updated CNMResponse task to not require cmrConceptId and cmrLink in granule input.
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **Snyk**
+  - Upgrade com.amazonaws:aws-java-sdk-core:1.11.955 -> 1.11.1013
+  - Upgrade com.amazonaws:aws-java-sdk-kinesis:1.11.955 -> 1.11.1013
+  - Upgrade com.amazonaws:aws-java-sdk-sns:1.11.955 -> 1.11.1013
+  - Upgrade commons-io:commons-io:2.6 -> 2.7
+
 # [v1.3.1] - 2021-02-17
 ### Added
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>
@@ -27,7 +27,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.11.955</version>
+    <version>1.11.1013</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
@@ -39,7 +39,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.11.955</version>
+    <version>1.11.1013</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
@@ -56,12 +56,12 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.11.955</version>
+    <version>1.11.1013</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.6</version>
+    <version>2.7</version>
 </dependency>
 <dependency>
     <groupId>com.amazonaws</groupId>

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -9,7 +9,6 @@ import cumulus_message_adapter.message_parser.MessageAdapterException;
 import cumulus_message_adapter.message_parser.MessageParser;
 import gov.nasa.cumulus.bo.MessageAttribute;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -145,10 +144,13 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
             inputKey.get("product").getAsJsonObject().remove("name");
             inputKey.get("product").getAsJsonObject().addProperty("name", granuleId);
 
-            JsonObject ingestionMetadata = new JsonObject();
-            ingestionMetadata.addProperty("catalogId", granule.get("cmrConceptId").getAsString());
-            ingestionMetadata.addProperty("catalogUrl", granule.get("cmrLink").getAsString());
-            response.add("ingestionMetadata", ingestionMetadata);
+            // Only add CMR metadata if available
+            if (granule.get("cmrConceptId") != null && granule.get("cmrLink") != null) {
+                JsonObject ingestionMetadata = new JsonObject();
+                ingestionMetadata.addProperty("catalogId", granule.get("cmrConceptId").getAsString());
+                ingestionMetadata.addProperty("catalogUrl", granule.get("cmrLink").getAsString());
+                response.add("ingestionMetadata", ingestionMetadata);
+            }
         } else {
             inputKey.remove("product");
         }

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -260,6 +260,36 @@ public class AppTest
 		assertEquals("https://cmr.uat.earthdata.nasa.gov/search/granules.json?concept_id=G1234313662-POCUMULUS", ingestionMetadata.get("catalogUrl").getAsString());
 	}
 
+	/**
+	 * Test success CNM response with no CMR link
+	 */
+	public void testSuccessCnmNoCmr() throws Exception {
+		ClassLoader classLoader = getClass().getClassLoader();
+		File inputJsonFile = new File(classLoader.getResource("workflow.success.no.cmr.json").getFile());
+
+		String input = "";
+		try {
+			input = new String(Files.readAllBytes(inputJsonFile.toPath()));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+
+		JsonObject inputConfig = inputKey.getAsJsonObject("config");
+		String cnm = new Gson().toJson(inputConfig.get("OriginalCNM"));
+
+		JsonObject granule = inputKey.get("input").getAsJsonObject().get("granules").getAsJsonArray().get(0).getAsJsonObject();
+
+		String output = CNMResponse.generateOutput(cnm, null, granule, inputConfig);
+		JsonElement outputElement = new JsonParser().parse(output);
+		JsonObject response = outputElement.getAsJsonObject().get("response").getAsJsonObject();
+
+		JsonElement ingestionMetadata = response.get("ingestionMetadata");
+		assertNull(ingestionMetadata);
+	}
+
 	public void testBuildMessageAttributesHash() {
 		CNMResponse cnmResponse = new CNMResponse();
 		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS");

--- a/src/test/resources/workflow.success.no.cmr.json
+++ b/src/test/resources/workflow.success.no.cmr.json
@@ -1,0 +1,95 @@
+{
+    "input": {
+        "granules": [
+            {
+                "files": [
+                    {
+                        "checksumType": "md5",
+                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "checksumType": "md5",
+                        "checksum": "3b6de83e361a01867a9e541a4bf771dc",
+                        "bucket": "test-protected",
+                        "filename": "s3://test-protected/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "path": "c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles",
+                        "url_path": "",
+                        "type": "data",
+                        "duplicate_found": true,
+                        "size": 18795152
+                    },
+                    {
+                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "checksumType": "md5",
+                        "checksum": "11236de83e361eesss332f771dc",
+                        "bucket": "test-public",
+                        "filename": "s3://test-public/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "url_path": "",
+                        "type": "metadata",
+                        "size": 1236
+                    }
+                ],
+                "dataType": "MERGED_TP_J1_OSTM_OST_CYCLES_V42",
+                "cmrMetadataFormat": "umm_json_v1_6",
+                "sync_granule_duration": 3136,
+                "granuleId": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2",
+                "version": "1",
+                "published": true,
+                "post_to_cmr_duration": 11650
+            }
+        ]
+    },
+    "messageConfig": {
+        "outputs": [
+            {
+                "source": "{$.cnm}",
+                "destination": "{$.meta.cnmResponse}"
+            },
+            {
+                "source": "{$.input.input}",
+                "destination": "{$.payload}"
+            }
+        ]
+    },
+    "config": {
+        "response-endpoint": "arn:aws:sns:us-west-2:111111111111:test-provider-response-sns",
+        "distribution_endpoint": "https://te31m541y2.execute-api.us-west-2.amazonaws.com:9001/DEV/",
+        "OriginalCNM": {
+            "product": {
+                "files": [
+                    {
+                        "checksumType": "md5",
+                        "checksum": "",
+                        "uri": "s3://podaac-sndbx-staging/c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "type": "data",
+                        "size": 18795152
+                    },
+                    {
+                        "checksumType": "md5",
+                        "checksum": "",
+                        "uri": "s3://podaac-sndbx-staging/c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc.md5",
+                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc.md5",
+                        "type": "data",
+                        "size": 83
+                    }
+                ],
+                "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                "dataVersion": "1.0"
+            },
+            "receivedTime": "2020-04-08T16:00:16.958Z",
+            "collection": "MERGED_TP_J1_OSTM_OST_CYCLES_V42",
+            "version": "1.1",
+            "provider": "NASA/JPL/PO.DAAC",
+            "submissionTime": "2020-04-08 15:59:15.186779",
+            "identifier": "c1f1be11-9cbd-4620-ad07-9a7f2afb8349"
+        },
+        "region": "us-west-2",
+        "WorkflowException": "None",
+        "type": "sns"
+    },
+    "cumulus_config": {
+        "state_machine": "arn:aws:states:us-west-2:111111111111:stateMachine:test-IngestKinesis",
+        "execution_name": "b5729c30-226e-4184-8993-cfad70a2758b"
+    }
+}


### PR DESCRIPTION
Ticket: [PCESA-2418](https://bugs.earthdata.nasa.gov/browse/PCESA-2418)

### Description

NSIDC has a use case for running CNMResponse task before PostToCMR.

### Overview of work done

Check if cmrLink and cmrConceptId exists in the input before adding to CNM-R.
Upgraded dependencies to fix Synk vulnerabilities.

### Overview of verification done

#### Tested in sandbox:

Removed PostToCmr step in IngestWorkflow and confirmed CNM-R is still published without ingestionMetadata.
Added PostToCmr back and confirmed CNM-R is published with ingestionMetadata.

## PR checklist:

* [ ] Linted
* [X] Unit tests
* [X] Updated changelog
* [X] Tested in sandbox

