### PR TITLE
Update CnmResponse lambda to be compatible with updated granule.files schema

### DIFF
--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -117,13 +117,14 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
                 f.addProperty("type", e.getAsJsonObject().getAsJsonPrimitive("type").getAsString());
                 // subtype : skip
                 // name
-                f.addProperty("name", e.getAsJsonObject().getAsJsonPrimitive("name").getAsString());
+                f.addProperty("fileName", e.getAsJsonObject().getAsJsonPrimitive("fileName").getAsString());
                 // uri
-                String filename = e.getAsJsonObject().getAsJsonPrimitive("filename").getAsString();
-                filename = filename.replace("s3://", "/");
+                String bucket = e.getAsJsonObject().getAsJsonPrimitive("bucket").getAsString();
+                String key = e.getAsJsonObject().getAsJsonPrimitive("key").getAsString();
+                String filepath = bucket + '/' + key;
                 try {
                     URIBuilder uriBuilder = new URIBuilder(distribute_url);
-                    f.addProperty("uri", uriBuilder.setPath(uriBuilder.getPath() + filename).build().normalize().toString());
+                    f.addProperty("uri", uriBuilder.setPath(uriBuilder.getPath() + filepath).build().normalize().toString());
                 } catch (URISyntaxException uriSyntaxException) {
                     throw uriSyntaxException;
                 }

--- a/src/test/resources/workflow.error.json
+++ b/src/test/resources/workflow.error.json
@@ -5,12 +5,10 @@
                 "granuleId": "L1B_HR_SLC_product_0001-of-4154",
                 "files": [
                     {
-                        "name": "L1B_HR_SLC_product_0001-of-4154.h5",
+                        "fileName": "L1B_HR_SLC_product_0001-of-4154.h5",
                         "bucket": "podaac-dev-cumulus-test-input",
                         "checksumType": "md5",
                         "checksum": "1mm36de83e32233s332f771dc",
-                        "path": "L1B_HR_SLC",
-                        "filename": "s3://podaac-dev-cumulus-test-input/L1B_HR_SLC/L1B_HR_SLC_product_0001-of-4154.h5",
                         "size": 3769638960,
                         "type": "data"
                     }

--- a/src/test/resources/workflow.success.json
+++ b/src/test/resources/workflow.success.json
@@ -5,26 +5,19 @@
                 "files": [
                     {
                         "checksumType": "md5",
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "checksumType": "md5",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
                         "checksum": "3b6de83e361a01867a9e541a4bf771dc",
                         "bucket": "test-protected",
-                        "filename": "s3://test-protected/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "path": "c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles",
-                        "url_path": "",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
                         "type": "data",
-                        "duplicate_found": true,
                         "size": 18795152
                     },
                     {
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
                         "checksumType": "md5",
                         "checksum": "11236de83e361eesss332f771dc",
                         "bucket": "test-public",
-                        "filename": "s3://test-public/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "url_path": "",
                         "type": "metadata",
                         "size": 1236
                     }

--- a/src/test/resources/workflow.success.no.cmr.json
+++ b/src/test/resources/workflow.success.no.cmr.json
@@ -5,26 +5,19 @@
                 "files": [
                     {
                         "checksumType": "md5",
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "checksumType": "md5",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
                         "checksum": "3b6de83e361a01867a9e541a4bf771dc",
                         "bucket": "test-protected",
-                        "filename": "s3://test-protected/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "path": "c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles",
-                        "url_path": "",
                         "type": "data",
-                        "duplicate_found": true,
                         "size": 18795152
                     },
                     {
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
                         "checksumType": "md5",
                         "checksum": "11236de83e361eesss332f771dc",
                         "bucket": "test-public",
-                        "filename": "s3://test-public/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "url_path": "",
                         "type": "metadata",
                         "size": 1236
                     }


### PR DESCRIPTION
For CUMULUS-2388, we are updating our workflow task schemas to be internally consistent in the schema for granule files. We are also ensuring that the schema for granule files used by workflow tasks matches what is supported by our database, so that we can avoid issues with bulk granule workflow operations that pass granules from our database into new workflows.

As a result of this work, some file properties like `filename`, `name`, and others have been deprecated, which are breaking changes to this Lambda. 

Given that we need an updated version of the CnmResponse task for our internal integration tests on Cumulus to pass, I've gone ahead and updated this Lambda to match the new task schema. All of the unit tests are passing on my local machine.