### PR TITLE
Release/2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+### Added
+### Changed
+- **CUMULUS-2388**
+  - Updated CNMResponse task to use fileName, bucket and key from Cumulus granule files object.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 # [v1.4.1] - 2021-07-21
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
+# [v2.0.0] - 2021-09-24
 ### Added
 ### Changed
 - **CUMULUS-2388**

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>1.4.1</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -117,13 +117,14 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
                 f.addProperty("type", e.getAsJsonObject().getAsJsonPrimitive("type").getAsString());
                 // subtype : skip
                 // name
-                f.addProperty("name", e.getAsJsonObject().getAsJsonPrimitive("name").getAsString());
+                f.addProperty("name", e.getAsJsonObject().getAsJsonPrimitive("fileName").getAsString());
                 // uri
-                String filename = e.getAsJsonObject().getAsJsonPrimitive("filename").getAsString();
-                filename = filename.replace("s3://", "/");
+                String bucket = e.getAsJsonObject().getAsJsonPrimitive("bucket").getAsString();
+                String key = e.getAsJsonObject().getAsJsonPrimitive("key").getAsString();
+                String filepath = bucket + '/' + key;
                 try {
                     URIBuilder uriBuilder = new URIBuilder(distribute_url);
-                    f.addProperty("uri", uriBuilder.setPath(uriBuilder.getPath() + filename).build().normalize().toString());
+                    f.addProperty("uri", uriBuilder.setPath(uriBuilder.getPath() + filepath).build().normalize().toString());
                 } catch (URISyntaxException uriSyntaxException) {
                     throw uriSyntaxException;
                 }

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -241,7 +241,6 @@ public class AppTest
 		JsonObject product = outputElement.getAsJsonObject().get("product").getAsJsonObject();
 		assertEquals("SUCCESS", response.get("status").getAsString());
 
-
 		assertEquals("1.0", product.get("dataVersion").getAsString());
 		assertEquals(2, product.get("files").getAsJsonArray().size());
 		JsonArray files = product.get("files").getAsJsonArray();
@@ -249,8 +248,12 @@ public class AppTest
 		assertEquals("Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2", product.get("name").getAsString());
 		assertEquals("https://te31m541y2.execute-api.us-west-2.amazonaws.com:9001/DEV/test-protected/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
 				files.get(0).getAsJsonObject().getAsJsonPrimitive("uri").getAsString());
+		assertEquals("Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+				files.get(0).getAsJsonObject().getAsJsonPrimitive("name").getAsString());
 		assertEquals("https://te31m541y2.execute-api.us-west-2.amazonaws.com:9001/DEV/test-public/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
 				files.get(1).getAsJsonObject().getAsJsonPrimitive("uri").getAsString());
+		assertEquals("Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+				files.get(1).getAsJsonObject().getAsJsonPrimitive("name").getAsString());
 		// product.name should be the granuleId
 		assertEquals("Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2", product.get("name").getAsString());
 

--- a/src/test/resources/workflow.error.json
+++ b/src/test/resources/workflow.error.json
@@ -5,12 +5,11 @@
                 "granuleId": "L1B_HR_SLC_product_0001-of-4154",
                 "files": [
                     {
-                        "name": "L1B_HR_SLC_product_0001-of-4154.h5",
+                        "fileName": "L1B_HR_SLC_product_0001-of-4154.h5",
+                        "key": "L1B_HR_SLC/L1B_HR_SLC_product_0001-of-4154.h5",
                         "bucket": "podaac-dev-cumulus-test-input",
                         "checksumType": "md5",
                         "checksum": "1mm36de83e32233s332f771dc",
-                        "path": "L1B_HR_SLC",
-                        "filename": "s3://podaac-dev-cumulus-test-input/L1B_HR_SLC/L1B_HR_SLC_product_0001-of-4154.h5",
                         "size": 3769638960,
                         "type": "data"
                     }

--- a/src/test/resources/workflow.success.json
+++ b/src/test/resources/workflow.success.json
@@ -5,26 +5,19 @@
                 "files": [
                     {
                         "checksumType": "md5",
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "checksumType": "md5",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
                         "checksum": "3b6de83e361a01867a9e541a4bf771dc",
                         "bucket": "test-protected",
-                        "filename": "s3://test-protected/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "path": "c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles",
-                        "url_path": "",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
                         "type": "data",
-                        "duplicate_found": true,
                         "size": 18795152
                     },
                     {
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
                         "checksumType": "md5",
                         "checksum": "11236de83e361eesss332f771dc",
                         "bucket": "test-public",
-                        "filename": "s3://test-public/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "url_path": "",
                         "type": "metadata",
                         "size": 1236
                     }

--- a/src/test/resources/workflow.success.no.cmr.json
+++ b/src/test/resources/workflow.success.no.cmr.json
@@ -5,26 +5,19 @@
                 "files": [
                     {
                         "checksumType": "md5",
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "checksumType": "md5",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
                         "checksum": "3b6de83e361a01867a9e541a4bf771dc",
                         "bucket": "test-protected",
-                        "filename": "s3://test-protected/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.nc",
-                        "path": "c1f1be11-9cbd-4620-ad07-9a7f2afb8349/store/merged_alt/open/L2/TP_J1_OSTM/cycles",
-                        "url_path": "",
                         "type": "data",
-                        "duplicate_found": true,
                         "size": 18795152
                     },
                     {
-                        "name": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "filepath": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "fileName": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
+                        "key": "Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
                         "checksumType": "md5",
                         "checksum": "11236de83e361eesss332f771dc",
                         "bucket": "test-public",
-                        "filename": "s3://test-public/Merged_TOPEX_Jason_OSTM_Jason-3_Cycle_945.V4_2.cmr.json",
-                        "url_path": "",
                         "type": "metadata",
                         "size": 1236
                     }


### PR DESCRIPTION
# [v2.0.0] - 2021-09-24
### Added
### Changed
- **CUMULUS-2388**
  - Updated CNMResponse task to use fileName, bucket and key from Cumulus granule files object.
### Deprecated
### Removed
### Fixed
### Security