### PR TITLE
Feature/podaac 3920

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GIT_PUSH_TOKEN }}
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
@@ -144,5 +146,5 @@ jobs:
         run: |
           git config --global user.name 'podaac-cloud-IandA'
           git config --global user.email 'podaac-cloud-IandA@jpl.nasa.gov'
-          git commit -m "/version ${{ env.software_version }}" pom.xml
+          git commit -m "/version ${{ env.software_version }} [skip actions]" pom.xml
           git push

--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -11,9 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   ARTIFACT_BASE_NAME: cnmResponse
-  # Need to change owner back
-  UPLOAD_URL: https://api.github.com/repos/cbanh/cumulus-cnm-response-task
-  GITHUB_USER: cbanh
 
 jobs:
   # First job name

--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -1,0 +1,151 @@
+name: Build
+
+on:
+  # Triggers the workflow on push events
+  push:
+    branches: [ develop, release/**, feature/**, master, main ]
+
+    # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  ARTIFACT_BASE_NAME: cnmResponse
+  # Need to change owner back
+  UPLOAD_URL: https://api.github.com/repos/cbanh/cumulus-cnm-response-task
+  GITHUB_USER: cbanh
+
+jobs:
+  # First job name
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8.0.232'
+      - uses: gradle/gradle-build-action@v1
+        with:
+          gradle-version: 4.0.1
+      - name: Install Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Python dependencies
+        run: |
+          pip3 install -r builder/requirements.txt
+      - name: Extract Maven project version
+        run: echo ::set-output name=current_version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+        id: get-version
+      - name: Show extracted Maven project version
+        run: |
+          echo ${{ steps.get-version.outputs.current_version }}
+          base_ver="$(python3 builder/bump-version.py -v ${{ steps.get-version.outputs.current_version }} --get-base)"
+          echo "base_ver=$base_ver" >> $GITHUB_ENV
+      - name: Bump pre-alpha version
+        # If triggered by push to a feature branch
+        if: ${{ startsWith(github.ref, 'refs/heads/feature/') }}
+        run: |
+          git_sha="$(git rev-parse --short ${GITHUB_SHA})"          
+          echo "git sha=$git_sha"
+          new_ver="${base_ver}+$git_sha"
+          echo "software_version=$new_ver" >> $GITHUB_ENV
+      - name: Bump alpha version
+        # If triggered by push to the develop branch
+        if: ${{ github.ref == 'refs/heads/develop' }}
+        run: |
+          bump_ver="$(python3 builder/bump-version.py -v ${{ steps.get-version.outputs.current_version }})"
+          if [[ "$bump_ver" == "None" ]]; then
+            bump_ver='0'
+          fi
+          new_ver="${base_ver}-alpha.${bump_ver}-SNAPSHOT"
+          echo "software_version=$new_ver" >> $GITHUB_ENV
+      - name: Bump rc version
+        # If triggered by push to a release branch
+        if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          bump_ver="$(python3 builder/bump-version.py -v ${{ steps.get-version.outputs.current_version }})"
+          if [[ "$bump_ver" == "None" ]]; then
+            bump_ver='0'
+          fi
+          new_ver="${base_ver}-rc.${bump_ver}"
+          echo "software_version=$new_ver" >> $GITHUB_ENV
+      - name: Release version
+        # If triggered by push to the master branch
+        if: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        run: |
+          new_ver="${base_ver}"
+          echo "software_version=$new_ver" >> $GITHUB_ENV
+      - name: Build new version
+        run: |
+          echo "New Version is: ${{ env.software_version }}"
+          python3 builder/builder2.py -d . -a ${{env.ARTIFACT_BASE_NAME}} -v ${{ env.software_version }}
+      - name: Prepare Artifacts
+        run: |
+          artifact_file_name="${{ env.ARTIFACT_BASE_NAME }}-${{ env.software_version }}.zip"
+          echo "ARTIFACT_FILE=$artifact_file_name" >> $GITHUB_ENV
+          cp release/*.zip "$artifact_file_name"
+      - name: Create Release
+        id: create_release
+        if: ${{ contains(github.ref, 'master') }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: "v${{ env.software_version }}"
+          release_name: "Release v${{ env.software_version }} - ${{ github.ref }}"
+          body: |
+            Changes in this release:
+            ${{ github.event.head_commit.message }}
+          body_path: release.md
+          draft: false
+          prerelease: false
+      - name: Create PreRelease
+        id: create_prerelease
+        if: ${{ !contains(github.ref, 'master') }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: "v${{ env.software_version }}"
+          release_name: "Release v${{ env.software_version }} - ${{ github.ref }}"
+          body: |
+            Changes in this release:
+            ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: true
+      - name: Upload PreRelease Asset
+        id: upload-prerelease-asset 
+        if: ${{ !contains(github.ref, 'master') }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_prerelease.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: "${{ env.ARTIFACT_FILE }}"
+          asset_name: "${{ env.ARTIFACT_FILE }}"
+          asset_content_type: application/zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        if: ${{ contains(github.ref, 'master') }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: "${{ env.ARTIFACT_FILE }}"
+          asset_name: "${{ env.ARTIFACT_FILE }}"
+          asset_content_type: application/zip
+      - name: Commit Version Bump
+        # If building develop, a release branch, or master then we commit the version bump back to the repo
+        if: |
+          github.ref == 'refs/heads/develop' ||
+          github.ref == 'refs/heads/master'  ||
+          startsWith(github.ref, 'refs/heads/release')
+        run: |
+          git config --global user.name 'podaac-cloud-IandA'
+          git config --global user.email 'podaac-cloud-IandA@jpl.nasa.gov'
+          git commit -m "/version ${{ env.software_version }}" pom.xml
+          git push

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile fileTree(dir: 'target/dependency/', include: '*.jar')
+    implementation fileTree(dir: 'target/dependency/', include: '*.jar')
 }
 
 task buildZip(type: Zip) {
@@ -11,7 +11,7 @@ task buildZip(type: Zip) {
     from compileJava
     from processResources
     into('lib') {
-        from configurations.runtime
+        from configurations.runtimeClasspath
     }
     archiveName 'cnmResponse.zip'
 }

--- a/builder/builder2.py
+++ b/builder/builder2.py
@@ -1,0 +1,140 @@
+import click
+import os
+import sys
+import logging
+
+TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S'
+SHORT_TIMESTAMP_FORMAT = '%Y-%m-%d'
+
+logger:object = logging.getLogger('Artifact Builder ===>')
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+class builder:
+    def __init__(self, *args, **kwargs) -> None:
+        print('Builder started')
+
+    def find_executable(self, executable, path=None):
+        """Tries to find 'executable' in the directories listed in 'path'.
+
+        A string listing directories separated by 'os.pathsep'; defaults to
+        os.environ['PATH'].  Returns the complete filename or None if not found.
+        """
+        if path is None:
+            path = os.environ.get('PATH', os.defpath)
+
+        paths = path.split(os.pathsep)
+        base, ext = os.path.splitext(executable)
+
+        if (sys.platform == 'win32' or os.name == 'os2') and (ext != '.exe'):
+            executable = executable + '.exe'
+
+        if not os.path.isfile(executable):
+            for p in paths:
+                f = os.path.join(p, executable)
+                if os.path.isfile(f):
+                    # the file exists, we have a shot at spawn working
+                    return f
+            return None
+        else:
+            return executable
+
+    def clean_up(self, project_dir:str):
+        target_dir = os.path.join(project_dir, 'target')
+        build_dir = os.path.join(project_dir, 'build')
+        os.system('rm -Rf {}'.format(target_dir))
+        os.system('rm -Rf {}'.format(build_dir))
+
+@click.command()
+@click.option('-d', '--project-dir',
+              help='Project working directory', required=True, type=str)
+@click.option('-a', '--artifact-base-name',
+              help='artifact base name without .zip. Ex. cnmToGranule', required=True, type=str)
+@click.option('-v', '--version',
+              help='New version Ex. 2.0.0-shahash', required=True, type=str)
+def process(project_dir:str, artifact_base_name:str, version:str) -> None:
+    '''
+        this entire process is meant to run either through command line or inside a docker container
+        which contains java 8, python 3 , pipe and zip utilities.
+        The process will call a lot of os.system to similar command line maven and gradle build.
+        As well as manipulating pom file by reading and changing the <version>
+        As long as the version is ending with -SNAPSHOT, the build will be started
+    '''
+    logger.info('project directory:{}'.format('project_dir'))
+    logger.info('artifact name: {}'.format(artifact_base_name))
+    builder_o = builder()
+    mvn_executable:str = builder_o.find_executable('mvn')
+    gradle_executable:str = builder_o.find_executable('gradle')
+    logger.info('maven executable: {}'.format(mvn_executable))
+    logger.info('gradle executable:{}'.format(gradle_executable))
+    os.system('pwd')
+    os.chdir(project_dir)
+    os.system('pwd')
+    # zip and tar.gz the source before build
+    logger.info('Initial cleaning up directory')
+    builder_o.clean_up(project_dir)
+    '''
+        Read maven pom.xml <version>
+    '''
+    stream_pom_version = os.popen('mvn help:evaluate -Dexpression=project.version -q -DforceStdout')
+    pom_version: str = stream_pom_version.read()
+    logger.info('Read version from pom.xml:{}'.format(pom_version))
+    # if pom_version.lower().find('snapshot') == -1:
+    #     logger.info('There is no SNAPSHOT in pom version. Stopping build ...')
+    #     exit(0)
+    # else:
+    #     release_version:str = pom_version.lower().replace('-snapshot','')
+    #     logger.info('After removing SNAPSHOT, release version:{}'.format(release_version))
+
+    # Maven clean and TEST
+    # find if TEST has Failue case equals 0 then advance otherwise, exit the program
+    os.system('{} clean'.format(mvn_executable))
+    stream_mvn_test = os.popen('{} test'.format(mvn_executable))
+    str_test_result: str = stream_mvn_test.read()
+    logger.info('Entire MVN TEST output: {}'.format(str_test_result))
+    if str_test_result.find('Failed tests:') == -1:
+        logger.info('MAVEN TEST SUCCEEDED.  Continue ...')
+    else:
+        logger.error('MAVEN TEST FAILURE.  Existing ...')
+        exit(1)
+    # Build artifact using maven and gradle commands
+    logger.info('Artifact is creating')
+    os.system('mvn dependency:copy-dependencies')
+    os.system('gradle -x test build')
+    logger.info('Artifact created')
+    # Check if ./releases directory existed, otherwise, create
+    release_dir: str = os.path.join(project_dir, 'release')
+    if not os.path.isdir(release_dir):
+        os.mkdir(release_dir)
+        logger.info('release directory created')
+    # Move build artifact to release directory.
+    logger.info('Moving built artifact to /release')
+    build_zip:str = os.path.join(project_dir,'build/distributions/{}.zip'.format(artifact_base_name))
+    release_zip:str = os.path.join(release_dir,artifact_base_name)
+    release_zip = os.path.join(release_dir,'{}-{}.zip'.format(artifact_base_name, version))
+    os.system('mv {} {}'.format(build_zip, release_zip))
+    logger.info('finished moving built artifact to /release')
+
+    # create version.txt
+    logger.info('Opening and writing version.txt with release version: '.format(version))
+    f = open(os.path.join(release_dir,'version.txt'), "w")
+    f.write(version)
+    f.close()
+    logger.info('Version.txt created')
+
+    # Modify the pom file and commit/push
+    logger.info('Modifying pom file version to : {}'.format(version))
+    pom_modify_version:str = 'mvn versions:set -DnewVersion={} versions:commit'.format(version)
+    os.system(pom_modify_version)
+    logger.info('Finished modifying pom file version to : {}'.format(version))
+
+    # Clean up target directory
+    logger.info('Final cleaning up and openup directories')
+    os.system('chmod -R 777 {}'.format(release_dir))
+    builder_o.clean_up(project_dir)
+    os.system('cd {}'.format(os.path.join(project_dir, 'builder')))
+    os.system('pwd')
+    os.system('chmod -Rf 777 *')
+    os.system('chmod -Rf 777 .*')
+
+if __name__ == '__main__':
+    builder_obj:object = builder()
+    process()

--- a/builder/bump-version.py
+++ b/builder/bump-version.py
@@ -15,9 +15,11 @@ import click
 # 1.2.3
 # 1.2.3+xy3z
 # 1.2.3-rc.1
+# 1.2.3-SNAPSHOT
 def bumpy(version:str, get_base):
     rc_reg = '.*rc\.\d+$'
     dev_reg = '.*alpha\.\d+.*'
+    snap_reg = '.*SNAPSHOT$'
 
     if re.match(rc_reg, version):        
         if get_base:
@@ -29,6 +31,8 @@ def bumpy(version:str, get_base):
             return print(version.split('-alpha')[0].strip())
         else:
             return print(int(version.split('-alpha.')[1].split('-')[0]) + 1)
+    elif re.match(snap_reg, version):
+            return print(version.split('-SNAPSHOT')[0].strip())
     else:
         if get_base:
             return print(version.strip())

--- a/builder/bump-version.py
+++ b/builder/bump-version.py
@@ -1,0 +1,40 @@
+import os
+import re
+import sys
+import click
+
+
+@click.command()
+@click.option('-v', '--version',
+              help='Version', required=True, type=str)
+@click.option('--get-base',
+              help='gets the base version', is_flag=True, default=False, required=False)
+
+# sample version
+# 1.2.3-alpha.0-SNAPSHOT
+# 1.2.3
+# 1.2.3+xy3z
+# 1.2.3-rc.1
+def bumpy(version:str, get_base):
+    rc_reg = '.*rc\.\d+$'
+    dev_reg = '.*alpha\.\d+.*'
+
+    if re.match(rc_reg, version):        
+        if get_base:
+            return print(version.split('-rc.')[0].strip())
+        else:
+            return print(int(version.split('-rc.')[1]) + 1)
+    elif re.match(dev_reg, version):
+        if get_base:
+            return print(version.split('-alpha')[0].strip())
+        else:
+            return print(int(version.split('-alpha.')[1].split('-')[0]) + 1)
+    else:
+        if get_base:
+            return print(version.strip())
+        else:
+            return print(None)
+
+
+if __name__ == '__main__':
+    bumpy()   

--- a/builder/get-version.py
+++ b/builder/get-version.py
@@ -1,0 +1,19 @@
+import click
+import os
+import sys
+import logging
+
+TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S'
+SHORT_TIMESTAMP_FORMAT = '%Y-%m-%d'
+
+logger:object = logging.getLogger('Artifact Builder ===>')
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+stream_pom_version = os.popen('mvn help:evaluate -Dexpression=project.version -q -DforceStdout')
+pom_version: str = stream_pom_version.read()
+
+base_version = pom_version.split('-')[0]
+
+logger.info('Base version: {}'.format(base_version))
+
+logger.info('Read version from pom.xml: {}'.format(pom_version))

--- a/release.md
+++ b/release.md
@@ -1,0 +1,9 @@
+# [v2.0.0] - 2021-09-24
+### Added
+### Changed
+- **CUMULUS-2388**
+  - Updated CNMResponse task to use fileName, bucket and key from Cumulus granule files object.
+### Deprecated
+### Removed
+### Fixed
+### Security


### PR DESCRIPTION
Added Github action CI files for building and publishing release.

Files:
- builder/builder2.py
- builder/bump-version.py
- builder/get-version.py
- .github/workflows/build-pipeline.yaml
- release.md
- requirements.txt

Notes:
Versions will be automatically bumped according to branch. There can not be a duplicate version in the master branch or the build will fail.

master: major.minor.patch
develop: major.minor.patch-alpha.build-SNAPSHOT
release: major.minor.patch-rc.build
feature: major.minor.patch+sha

# sample version
1.2.3-alpha.0-SNAPSHOT
1.2.3
1.2.3+xy3z
1.2.3-rc.1

  - release.md text will be published as part of the release from the master branch
  - remember to bump the major.minor.patch version from the feature or develop branch after a release from the master/main branch in the pom.xml file. This is currently kept manual to provide flexibility in the version.