### PR TITLE
Release/2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [v2.0.2] - 2021-12-22
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **PODAAC-4059**
+  - Upgrade to cumulus-message-adapter-java 1.3.7 to address [log4j vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)
+
 # [v2.0.1] - 2021-12-15
 ### Added
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.1-alpha.0-SNAPSHOT</version>
+  <version>2.0.2-alpha.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>
@@ -50,7 +50,7 @@
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
-  <version>1.3.5</version>
+  <version>1.3.7</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-kinesis -->
 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.1-alpha.2.0.1-SNAPSHOT</version>
+  <version>2.0.1-alpha.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.2-alpha.1-SNAPSHOT</version>
+  <version>2.0.2-alpha.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/release.md
+++ b/release.md
@@ -1,9 +1,9 @@
-# [v2.0.1] - 2021-12-15
+# [v2.0.2] - 2021-12-22
 ### Added
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
-- **PODAAC-4046**
-  - Upgrade to cumulus-message-adapter-java 1.3.5 to address log4j vulnerability
+- **PODAAC-4059**
+  - Upgrade to cumulus-message-adapter-java 1.3.7 to address [log4j vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)


### PR DESCRIPTION
# [v2.0.2] - 2021-12-22
### Added
### Changed
### Deprecated
### Removed
### Fixed
### Security
- **PODAAC-4059**
  - Upgrade to cumulus-message-adapter-java 1.3.7 to address [log4j vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)