### PR TITLE
Feature/podaac 4055

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **PODAAC-4055**
+  - Upgrade dependencies to overcome Snyk warnings
+
+
 # [v2.0.2] - 2021-12-22
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
+# [v2.0.3] - 2022-01-21
 ### Added
 ### Changed
 ### Deprecated
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **PODAAC-4055**
   - Upgrade dependencies to overcome Snyk warnings
+  - Upgrade com.amazonaws:aws-java-sdk-core@1.12.28 to com.amazonaws:aws-java-sdk-core@1.12.144
+  - Upgrade com.amazonaws:aws-java-sdk-sns@1.12.28 to com.amazonaws:aws-java-sdk-sns@1.12.144
+  - Upgrade com.amazonaws:aws-java-sdk-kinesis@1.12.28 to com.amazonaws:aws-java-sdk-kinesis@1.12.144
+  - Upgrade com.amazonaws:amazon-kinesis-client@1.14.4 to com.amazonaws:amazon-kinesis-client@1.14.7
+  - Upgrade com.google.code.gson:gson@2.8.2 to com.google.code.gson:gson@2.8.9
+  - Upgrade commons-io@2.7 to commons-io@2.11.0
 - **PODAAC-4095**
   - Upgrade to cumulus-message-adapter 1.3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **PODAAC-4055**
   - Upgrade dependencies to overcome Snyk warnings
-
+- **PODAAC-4095**
+  - Upgrade to cumulus-message-adapter 1.3.9
 
 # [v2.0.2] - 2021-12-22
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
-  <version>1.3.7</version>
+  <version>1.3.9</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-kinesis -->
 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,25 +27,25 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.28</version>
+    <version>1.12.131</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-client</artifactId>
-    <version>1.14.4</version>
+    <version>1.14.7</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sns -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.28</version>
+    <version>1.12.131</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson</artifactId>
-    <version>2.8.2</version>
+    <version>2.8.9</version>
 </dependency>
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>
@@ -56,7 +56,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.28</version>
+    <version>1.12.131</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.2</version>
+  <version>2.0.3-alpha.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.7</version>
+    <version>2.11.0</version>
 </dependency>
 <dependency>
     <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.131</version>
+    <version>1.12.144</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
@@ -39,7 +39,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.131</version>
+    <version>1.12.144</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
@@ -56,7 +56,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.131</version>
+    <version>1.12.144</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>


### PR DESCRIPTION
Ticket: [PODAAC-4055](https://jira.jpl.nasa.gov/browse/PODAAC-4055)
and and PODAAC-4095

### Description

Upgrade dependencies to overcome Snyk warnings.  Mainly for gson 2.8.2 -> 2.8.9
However, other un-resolvable warnings are still there due to latest AWS sdk libraries

### Overview of work done

Upgrade dependency versions
integration test

### Overview of verification done

Integration testing to make sure cnmResponse lambda is still working.
integration testing with MODIS_A


#### Tested in SIT:

N/A

## PR checklist:

* [x] Linted
* [x] Unit tests
* [x] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
