### PR TITLE
Release/2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [v2.0.3] - 2022-01-21
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **PODAAC-4055**
+  - Upgrade dependencies to overcome Snyk warnings
+  - Upgrade com.amazonaws:aws-java-sdk-core@1.12.28 to com.amazonaws:aws-java-sdk-core@1.12.144
+  - Upgrade com.amazonaws:aws-java-sdk-sns@1.12.28 to com.amazonaws:aws-java-sdk-sns@1.12.144
+  - Upgrade com.amazonaws:aws-java-sdk-kinesis@1.12.28 to com.amazonaws:aws-java-sdk-kinesis@1.12.144
+  - Upgrade com.amazonaws:amazon-kinesis-client@1.14.4 to com.amazonaws:amazon-kinesis-client@1.14.7
+  - Upgrade com.google.code.gson:gson@2.8.2 to com.google.code.gson:gson@2.8.9
+  - Upgrade commons-io@2.7 to commons-io@2.11.0
+- **PODAAC-4095**
+  - Upgrade to cumulus-message-adapter 1.3.9
+
 # [v2.0.2] - 2021-12-22
 ### Added
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.0-SNAPSHOT</version>
+  <version>2.0.3-alpha.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.1-SNAPSHOT</version>
+  <version>2.0.3-alpha.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.2-alpha.2-SNAPSHOT</version>
+  <version>2.0.3-alpha.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>
@@ -27,41 +27,41 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.28</version>
+    <version>1.12.144</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-client</artifactId>
-    <version>1.14.4</version>
+    <version>1.14.7</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sns -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.28</version>
+    <version>1.12.144</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson</artifactId>
-    <version>2.8.2</version>
+    <version>2.8.9</version>
 </dependency>
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>
   <artifactId>cumulus-message-adapter</artifactId>
-  <version>1.3.7</version>
+  <version>1.3.9</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-kinesis -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.28</version>
+    <version>1.12.144</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.7</version>
+    <version>2.11.0</version>
 </dependency>
 <dependency>
     <groupId>com.amazonaws</groupId>

--- a/release.md
+++ b/release.md
@@ -1,9 +1,17 @@
-# [v2.0.2] - 2021-12-22
+# [v2.0.3] - 2022-01-21
 ### Added
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
-- **PODAAC-4059**
-  - Upgrade to cumulus-message-adapter-java 1.3.7 to address [log4j vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)
+- **PODAAC-4055**
+  - Upgrade dependencies to overcome Snyk warnings
+  - Upgrade com.amazonaws:aws-java-sdk-core@1.12.28 to com.amazonaws:aws-java-sdk-core@1.12.144
+  - Upgrade com.amazonaws:aws-java-sdk-sns@1.12.28 to com.amazonaws:aws-java-sdk-sns@1.12.144
+  - Upgrade com.amazonaws:aws-java-sdk-kinesis@1.12.28 to com.amazonaws:aws-java-sdk-kinesis@1.12.144
+  - Upgrade com.amazonaws:amazon-kinesis-client@1.14.4 to com.amazonaws:amazon-kinesis-client@1.14.7
+  - Upgrade com.google.code.gson:gson@2.8.2 to com.google.code.gson:gson@2.8.9
+  - Upgrade commons-io@2.7 to commons-io@2.11.0
+- **PODAAC-4095**
+  - Upgrade to cumulus-message-adapter 1.3.9


### PR DESCRIPTION
# [v2.0.3] - 2022-01-21
### Added
### Changed
### Deprecated
### Removed
### Fixed
### Security
- **PODAAC-4055**
  - Upgrade dependencies to overcome Snyk warnings
  - Upgrade com.amazonaws:aws-java-sdk-core@1.12.28 to com.amazonaws:aws-java-sdk-core@1.12.144
  - Upgrade com.amazonaws:aws-java-sdk-sns@1.12.28 to com.amazonaws:aws-java-sdk-sns@1.12.144
  - Upgrade com.amazonaws:aws-java-sdk-kinesis@1.12.28 to com.amazonaws:aws-java-sdk-kinesis@1.12.144
  - Upgrade com.amazonaws:amazon-kinesis-client@1.14.4 to com.amazonaws:amazon-kinesis-client@1.14.7
  - Upgrade com.google.code.gson:gson@2.8.2 to com.google.code.gson:gson@2.8.9
  - Upgrade commons-io@2.7 to commons-io@2.11.0
- **PODAAC-4095**
  - Upgrade to cumulus-message-adapter 1.3.9