### PR TITLE
[PODAAC-4445] Add in dataProcessingType field when sending messageAttribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [v1.5.0] - 2022-04-28
+### Added
+- **PODAAC-4445**
+  - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field existsq
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **Snyk**
+  - Upgrade com.amazonaws:aws-java-sdk-core@1.12.144 to com.amazonaws:aws-java-sdk-core@1.12.201
+  - Upgrade com.amazonaws:amazon-kinesis-client@1.14.7 to com.amazonaws:amazon-kinesis-client@1.14.8
+
 # [v1.4.4] - 2021-01-21
 ### Added
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>1.4.4</version>
+  <version>1.5.0</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.201</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-client</artifactId>
-    <version>1.14.7</version>
+    <version>1.14.8</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sns -->
 <dependency>

--- a/src/main/java/gov/nasa/cumulus/IConstants.java
+++ b/src/main/java/gov/nasa/cumulus/IConstants.java
@@ -7,6 +7,7 @@ public interface IConstants {
     String COLLECTION_SHORT_NAME_ATTRIBUTE_KEY = "COLLECTION";
     String CNM_RESPONSE_STATUS_ATTRIBUTE_KEY = "CNM_RESPONSE_STATUS";
     String DATA_VERSION_ATTRIBUTE_KEY = "DATA_VERSION";
+    String DATA_PROCESSING_TYPE = "dataProcessingType";
     enum MessageFilterTypeEnum {
         String,
         Number

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -292,7 +292,7 @@ public class AppTest
 
 	public void testBuildMessageAttributesHash() {
 		CNMResponse cnmResponse = new CNMResponse();
-		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS");
+		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS", "forward");
 		MessageAttribute collectionBO = attributeBOMap.get(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY);
 		MessageAttribute statusBO = attributeBOMap.get(this.CNM_RESPONSE_STATUS_ATTRIBUTE_KEY);
 		MessageAttribute dataVersionBO = attributeBOMap.get(this.DATA_VERSION_ATTRIBUTE_KEY);


### PR DESCRIPTION
Note this PR is built on top of 1.4.4 and would be merged into 1.5.0 (new backward-compatible feature)

These changes introduce a new field `dataProcessingType` in the `MessageAttributes` section for SNS topics
note the field is only included if in the key `dataProcessingType` exists, else it's not sent

Fixes issues from SNYK findings