### PR TITLE
[PODAAC-4445b] (Cumulus 11) Add in dataProcessingType field when sending messageAttribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased] 
 ### Added
+- **PODAAC-4445**
+  - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field exists
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -317,8 +318,11 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         // convert the final output to a JsonObject, so we can get 'response status'
         JsonObject outputJsonObj = new JsonParser().parse(output).getAsJsonObject();
         String final_status = outputJsonObj.getAsJsonObject("response").get("status").getAsString();
+        String dataProcessingType = outputJsonObj.getAsJsonObject("product").has("dataProcessingType") ?
+                outputJsonObj.getAsJsonObject("product").get("dataProcessingType").getAsString() : null;
         if (method != null) {
-            Map<String, MessageAttribute> attributeBOMap = buildMessageAttributesHash(collection, dataVersion, final_status);
+            Map<String, MessageAttribute> attributeBOMap =
+                    buildMessageAttributesHash(collection, dataVersion, final_status, dataProcessingType);
             Sender sender = SenderFactory.getSender(region, method);
             sender.addMessageAttributes(attributeBOMap);
             if (endpoint.isJsonArray()) {
@@ -368,20 +372,35 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         }
     }
 
-    Map<String, MessageAttribute> buildMessageAttributesHash(String collection_name, String dataVersion, String status) {
+    Map<String, MessageAttribute> buildMessageAttributesHash(
+            String collection_name,
+            String dataVersion,
+            String status,
+            @Nullable String dataProcessingType) {
         Map<String, MessageAttribute> attributeBOMap = new HashMap<>();
+
         MessageAttribute collectionNameBO = new MessageAttribute();
         collectionNameBO.setType(MessageFilterTypeEnum.String);
         collectionNameBO.setValue(collection_name);
         attributeBOMap.put(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY, collectionNameBO);
+
         MessageAttribute statusBO = new MessageAttribute();
         statusBO.setType(MessageFilterTypeEnum.String);
         statusBO.setValue(status);
         attributeBOMap.put(this.CNM_RESPONSE_STATUS_ATTRIBUTE_KEY, statusBO);
+
         MessageAttribute dataVersionBO = new MessageAttribute();
         dataVersionBO.setType(MessageFilterTypeEnum.String);
         dataVersionBO.setValue(dataVersion);
         attributeBOMap.put(this.DATA_VERSION_ATTRIBUTE_KEY, dataVersionBO);
+
+        if(null != dataProcessingType && !dataProcessingType.isEmpty()){
+            MessageAttribute dataProcessingTypeBO = new MessageAttribute();
+            dataProcessingTypeBO.setType(MessageFilterTypeEnum.String);
+            dataProcessingTypeBO.setValue(dataProcessingType);
+            attributeBOMap.put(this.DATA_PROCESSING_TYPE, dataProcessingTypeBO);
+        }
+
         return attributeBOMap;
     }
 }

--- a/src/main/java/gov/nasa/cumulus/IConstants.java
+++ b/src/main/java/gov/nasa/cumulus/IConstants.java
@@ -7,6 +7,7 @@ public interface IConstants {
     String COLLECTION_SHORT_NAME_ATTRIBUTE_KEY = "COLLECTION";
     String CNM_RESPONSE_STATUS_ATTRIBUTE_KEY = "CNM_RESPONSE_STATUS";
     String DATA_VERSION_ATTRIBUTE_KEY = "DATA_VERSION";
+    String DATA_PROCESSING_TYPE = "dataProcessingType";
     enum MessageFilterTypeEnum {
         String,
         Number

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -295,7 +295,7 @@ public class AppTest
 
 	public void testBuildMessageAttributesHash() {
 		CNMResponse cnmResponse = new CNMResponse();
-		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS");
+		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS", "forward");
 		MessageAttribute collectionBO = attributeBOMap.get(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY);
 		MessageAttribute statusBO = attributeBOMap.get(this.CNM_RESPONSE_STATUS_ATTRIBUTE_KEY);
 		MessageAttribute dataVersionBO = attributeBOMap.get(this.DATA_VERSION_ATTRIBUTE_KEY);


### PR DESCRIPTION
Implement same changes done in PR #117 ; this PR is built on top of cumulus 10 changes