### PR TITLE
Release/2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+# [Unreleased] 
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **PODAAC-4353**
+  - Fixed Snyk warning. 
+  - com.amazonaws:aws-java-sdk-core@1.12.144 to com.amazonaws:aws-java-sdk-core@1.12.206
+  - com.amazonaws:amazon-kinesis-client@1.14.7 to com.amazonaws:amazon-kinesis-client@1.14.8
+  - com.amazonaws:aws-java-sdk-sns@1.12.144 to com.amazonaws:aws-java-sdk-sns@1.12.206
+  - com.amazonaws:aws-java-sdk-kinesis@1.12.144 to com.amazonaws:aws-java-sdk-kinesis@1.12.206
+  - com.amazonaws:aws-lambda-java-core@1.1.0 to com.amazonaws:aws-lambda-java-core@1.2.1
+
 # [v2.0.3] - 2022-01-21
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased] 
 ### Added
+- **PODAAC-4445**
+  - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field exists
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-# [Unreleased] 
+# [2.1.0] 
 ### Added
 - **PODAAC-4445 & PODAAC-4574**
   - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased] 
 ### Added
-- **PODAAC-4445**
+- **PODAAC-4445 & PODAAC-4574**
   - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field exists
 ### Changed
 ### Deprecated
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - com.amazonaws:aws-java-sdk-sns@1.12.144 to com.amazonaws:aws-java-sdk-sns@1.12.209
   - com.amazonaws:aws-java-sdk-kinesis@1.12.144 to com.amazonaws:aws-java-sdk-kinesis@1.12.209
   - com.amazonaws:aws-lambda-java-core@1.1.0 to com.amazonaws:aws-lambda-java-core@1.2.1
+  - com.google.code.gson:gson@2.8.9 to com.google.code.gson:gson@2.9.0
 
 # [v2.0.3] - 2022-01-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **PODAAC-4445 & PODAAC-4574**
   - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field exists
+- **PODAAC-4606**
+  - Add in new field `trace` in the `MessageAttributes` section for SNS topics; would only populate when field exists
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **PODAAC-4353**
   - Fixed Snyk warning. 
-  - com.amazonaws:aws-java-sdk-core@1.12.144 to com.amazonaws:aws-java-sdk-core@1.12.206
+  - com.amazonaws:aws-java-sdk-core@1.12.144 to com.amazonaws:aws-java-sdk-core@1.12.209
   - com.amazonaws:amazon-kinesis-client@1.14.7 to com.amazonaws:amazon-kinesis-client@1.14.8
-  - com.amazonaws:aws-java-sdk-sns@1.12.144 to com.amazonaws:aws-java-sdk-sns@1.12.206
-  - com.amazonaws:aws-java-sdk-kinesis@1.12.144 to com.amazonaws:aws-java-sdk-kinesis@1.12.206
+  - com.amazonaws:aws-java-sdk-sns@1.12.144 to com.amazonaws:aws-java-sdk-sns@1.12.209
+  - com.amazonaws:aws-java-sdk-kinesis@1.12.144 to com.amazonaws:aws-java-sdk-kinesis@1.12.209
   - com.amazonaws:aws-lambda-java-core@1.1.0 to com.amazonaws:aws-lambda-java-core@1.2.1
 
 # [v2.0.3] - 2022-01-21

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.4-SNAPSHOT</version>
+  <version>2.0.3-alpha.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.2-SNAPSHOT</version>
+  <version>2.0.3-alpha.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.3-SNAPSHOT</version>
+  <version>2.0.3-alpha.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.209</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
@@ -39,7 +39,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.209</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
@@ -56,7 +56,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.209</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.206</version>
+    <version>1.12.209</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
@@ -39,7 +39,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.206</version>
+    <version>1.12.209</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
@@ -56,7 +56,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.206</version>
+    <version>1.12.209</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.6-SNAPSHOT</version>
+  <version>2.0.3-alpha.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.1-SNAPSHOT</version>
+  <version>2.0.3-alpha.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>gov.nasa.cumulus</groupId>
   <artifactId>cnm-response</artifactId>
-  <version>2.0.3-alpha.5-SNAPSHOT</version>
+  <version>2.0.3-alpha.6-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cnm-response</name>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 <dependency>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson</artifactId>
-    <version>2.8.9</version>
+    <version>2.9.0</version>
 </dependency>
 <dependency>
   <groupId>gov.nasa.earthdata</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,19 +27,19 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.206</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-client</artifactId>
-    <version>1.14.7</version>
+    <version>1.14.8</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sns -->
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.206</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 <dependency>
@@ -56,7 +56,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.144</version>
+    <version>1.12.206</version>
 </dependency>
 <dependency>
     <groupId>commons-io</groupId>
@@ -66,7 +66,7 @@
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-core</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.1</version>
 </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -234,6 +234,34 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
     }
 
     /**
+     * Gets the value for the 'dataProcessingType' field, to be used
+     * by the 'buildMessageAttributesHash' method.
+     * <br><br>
+     * Tries to use the 'OriginalCNM > Product > dataProcessingType' from the
+     * 'input > config' section, of the provided Json, but in case of an error,
+     * return a generic error string.
+     *<br><br>
+     * @param input     the input > config section, as a JsonObject
+     * @return          the string to use as the 'dataProcessingType' value; null if not available
+     */
+    public String getDataProcessingType(JsonObject input) {
+        String dataProcessingType = null;
+        // Implement a recursive json search function (find "dataProcessingType" else)
+        try {
+            if(input.has("OriginalCNM") &&
+                    input.getAsJsonObject("OriginalCNM").has("product") &&
+                    input.getAsJsonObject("OriginalCNM").getAsJsonObject("product").has("dataProcessingType")) {
+                dataProcessingType = input.getAsJsonObject("OriginalCNM").getAsJsonObject("product").get("dataProcessingType").getAsString();
+            }
+            return dataProcessingType;
+        } catch (Exception e) {
+            AdapterLogger.LogError(this.className + " handleRequest error:\n" + e.getMessage());
+            AdapterLogger.LogInfo("input content:\n" + input);
+            return null;
+        }
+    }
+
+    /**
      * Gets the value for the 'DataVersion' field, to be used
      * by the 'buildMessageAttributesHash' method.
      * <br><br>
@@ -305,21 +333,20 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      * using the 'response > status' field from the 'output'
      * along with the provided values for 'collection' and 'dataversion'
      * <br><br>
-     * @param output        the final output json message, as String
-     * @param method        the method to use, 'Kinesis' or 'Sns' when sending
-     * @param region        the region to send the message to
-     * @param endpoint      the actual endpoint for the message
-     * @param collection    the collection value for the attribute hash
-     * @param dataVersion   the dataVersion value for the attribute hash
+     * @param output             the final output json message, as String
+     * @param method             the method to use, 'Kinesis' or 'Sns' when sending
+     * @param region             the region to send the message to
+     * @param endpoint           the actual endpoint for the message
+     * @param collection         the collection value for the attribute hash
+     * @param dataVersion        the dataVersion value for the attribute hash
+     * @oaram dataProcessingType the dataProcessingType value for the attribute hash (can be null)
      */
     public void sendMessage(String output, String method, String region,
                                    JsonElement endpoint, String collection,
-                                   String dataVersion) {
+                                   String dataVersion, @Nullable String dataProcessingType) {
         // convert the final output to a JsonObject, so we can get 'response status'
         JsonObject outputJsonObj = new JsonParser().parse(output).getAsJsonObject();
         String final_status = outputJsonObj.getAsJsonObject("response").get("status").getAsString();
-        String dataProcessingType = outputJsonObj.getAsJsonObject("product").has("dataProcessingType") ?
-                outputJsonObj.getAsJsonObject("product").get("dataProcessingType").getAsString() : null;
         if (method != null) {
             Map<String, MessageAttribute> attributeBOMap =
                     buildMessageAttributesHash(collection, dataVersion, final_status, dataProcessingType);
@@ -350,10 +377,11 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         // get collection and dataVersion for use in message attribute hash
         String collection = getCollection(inputKey);
         String dataVersion = getDataVersion(inputConfig);
+        String dataProcessingType = getDataProcessingType(inputConfig);
         String output;
         try {
             output = buildMessage(inputKey, inputConfig);
-            sendMessage(output, method, region, responseEndpoint, collection, dataVersion);
+            sendMessage(output, method, region, responseEndpoint, collection, dataVersion, dataProcessingType);
             /* create new object:
              *
              * {cnm: output, input:input}
@@ -365,8 +393,9 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
             return new Gson().toJson(bigOutput);
         } catch (Exception ex) {
             AdapterLogger.LogError(this.className + " encountered exception with input String: " + input);
+            AdapterLogger.LogError(this.className + " handleRequest error:" + ex.getMessage());
             output = buildGeneralError(inputKey, ex.getMessage());
-            sendMessage(output, method, region, responseEndpoint, collection, dataVersion);
+            sendMessage(output, method, region, responseEndpoint, collection, dataVersion, dataProcessingType);
             // re-throw the exception now.
             throw ex;
         }

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -261,6 +261,22 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         }
     }
 
+    public String getTrace(JsonObject input) {
+        String trace = null;
+        // Implement a recursive json search function (find "trace" else)
+        try {
+            if(input.has("OriginalCNM") &&
+                    input.getAsJsonObject("OriginalCNM").has("trace")) {
+                trace = input.getAsJsonObject("OriginalCNM").get("trace").getAsString();
+            }
+            return trace;
+        } catch (Exception e) {
+            AdapterLogger.LogError(this.className + " handleRequest error:\n" + e.getMessage());
+            AdapterLogger.LogInfo("input content:\n" + input);
+            return null;
+        }
+    }
+
     /**
      * Gets the value for the 'DataVersion' field, to be used
      * by the 'buildMessageAttributesHash' method.
@@ -343,13 +359,13 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      */
     public void sendMessage(String output, String method, String region,
                                    JsonElement endpoint, String collection,
-                                   String dataVersion, @Nullable String dataProcessingType) {
+                                   String dataVersion, @Nullable String dataProcessingType, @Nullable String trace) {
         // convert the final output to a JsonObject, so we can get 'response status'
         JsonObject outputJsonObj = new JsonParser().parse(output).getAsJsonObject();
         String final_status = outputJsonObj.getAsJsonObject("response").get("status").getAsString();
         if (method != null) {
             Map<String, MessageAttribute> attributeBOMap =
-                    buildMessageAttributesHash(collection, dataVersion, final_status, dataProcessingType);
+                    buildMessageAttributesHash(collection, dataVersion, final_status, dataProcessingType, trace);
             Sender sender = SenderFactory.getSender(region, method);
             sender.addMessageAttributes(attributeBOMap);
             if (endpoint.isJsonArray()) {
@@ -378,10 +394,11 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         String collection = getCollection(inputKey);
         String dataVersion = getDataVersion(inputConfig);
         String dataProcessingType = getDataProcessingType(inputConfig);
+        String trace = getTrace(inputConfig);
         String output;
         try {
             output = buildMessage(inputKey, inputConfig);
-            sendMessage(output, method, region, responseEndpoint, collection, dataVersion, dataProcessingType);
+            sendMessage(output, method, region, responseEndpoint, collection, dataVersion, dataProcessingType, trace);
             /* create new object:
              *
              * {cnm: output, input:input}
@@ -395,7 +412,7 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
             AdapterLogger.LogError(this.className + " encountered exception with input String: " + input);
             AdapterLogger.LogError(this.className + " handleRequest error:" + ex.getMessage());
             output = buildGeneralError(inputKey, ex.getMessage());
-            sendMessage(output, method, region, responseEndpoint, collection, dataVersion, dataProcessingType);
+            sendMessage(output, method, region, responseEndpoint, collection, dataVersion, dataProcessingType, trace);
             // re-throw the exception now.
             throw ex;
         }
@@ -405,7 +422,8 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
             String collection_name,
             String dataVersion,
             String status,
-            @Nullable String dataProcessingType) {
+            @Nullable String dataProcessingType,
+            @Nullable String trace) {
         Map<String, MessageAttribute> attributeBOMap = new HashMap<>();
 
         MessageAttribute collectionNameBO = new MessageAttribute();
@@ -428,6 +446,13 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
             dataProcessingTypeBO.setType(MessageFilterTypeEnum.String);
             dataProcessingTypeBO.setValue(dataProcessingType);
             attributeBOMap.put(this.DATA_PROCESSING_TYPE, dataProcessingTypeBO);
+        }
+
+        if(null != trace && !trace.isEmpty()){
+            MessageAttribute traceBO = new MessageAttribute();
+            traceBO.setType(MessageFilterTypeEnum.String);
+            traceBO.setValue(trace);
+            attributeBOMap.put(this.TRACE, traceBO);
         }
 
         return attributeBOMap;

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -317,8 +318,11 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         // convert the final output to a JsonObject, so we can get 'response status'
         JsonObject outputJsonObj = new JsonParser().parse(output).getAsJsonObject();
         String final_status = outputJsonObj.getAsJsonObject("response").get("status").getAsString();
+        String dataProcessingType = outputJsonObj.getAsJsonObject("product").has("dataProcessingType") ?
+                outputJsonObj.getAsJsonObject("product").get("dataProcessingType").getAsString() : null;
         if (method != null) {
-            Map<String, MessageAttribute> attributeBOMap = buildMessageAttributesHash(collection, dataVersion, final_status);
+            Map<String, MessageAttribute> attributeBOMap =
+                    buildMessageAttributesHash(collection, dataVersion, final_status, dataProcessingType);
             Sender sender = SenderFactory.getSender(region, method);
             sender.addMessageAttributes(attributeBOMap);
             if (endpoint.isJsonArray()) {
@@ -368,20 +372,35 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
         }
     }
 
-    Map<String, MessageAttribute> buildMessageAttributesHash(String collection_name, String dataVersion, String status) {
+    Map<String, MessageAttribute> buildMessageAttributesHash(
+            String collection_name,
+            String dataVersion,
+            String status,
+            @Nullable String dataProcessingType) {
         Map<String, MessageAttribute> attributeBOMap = new HashMap<>();
+
         MessageAttribute collectionNameBO = new MessageAttribute();
         collectionNameBO.setType(MessageFilterTypeEnum.String);
         collectionNameBO.setValue(collection_name);
         attributeBOMap.put(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY, collectionNameBO);
+
         MessageAttribute statusBO = new MessageAttribute();
         statusBO.setType(MessageFilterTypeEnum.String);
         statusBO.setValue(status);
         attributeBOMap.put(this.CNM_RESPONSE_STATUS_ATTRIBUTE_KEY, statusBO);
+
         MessageAttribute dataVersionBO = new MessageAttribute();
         dataVersionBO.setType(MessageFilterTypeEnum.String);
         dataVersionBO.setValue(dataVersion);
         attributeBOMap.put(this.DATA_VERSION_ATTRIBUTE_KEY, dataVersionBO);
+
+        if(null != dataProcessingType && !dataProcessingType.isEmpty()){
+            MessageAttribute dataProcessingTypeBO = new MessageAttribute();
+            dataProcessingTypeBO.setType(MessageFilterTypeEnum.String);
+            dataProcessingTypeBO.setValue(dataProcessingType);
+            attributeBOMap.put(this.DATA_PROCESSING_TYPE, dataProcessingTypeBO);
+        }
+
         return attributeBOMap;
     }
 }

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -63,7 +63,7 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
             response.addProperty("status", "FAILURE");
 
             //logic for failure types here
-            JsonObject workflowException = new JsonParser().parse(exception).getAsJsonObject();
+            JsonObject workflowException = JsonParser.parseString(exception).getAsJsonObject();
 
             String error = workflowException.get("Error").getAsString();
             AdapterLogger.LogWarning(CNMResponse.class.getName() + " error:" + error);

--- a/src/main/java/gov/nasa/cumulus/IConstants.java
+++ b/src/main/java/gov/nasa/cumulus/IConstants.java
@@ -7,6 +7,7 @@ public interface IConstants {
     String COLLECTION_SHORT_NAME_ATTRIBUTE_KEY = "COLLECTION";
     String CNM_RESPONSE_STATUS_ATTRIBUTE_KEY = "CNM_RESPONSE_STATUS";
     String DATA_VERSION_ATTRIBUTE_KEY = "DATA_VERSION";
+    String DATA_PROCESSING_TYPE = "dataProcessingType";
     enum MessageFilterTypeEnum {
         String,
         Number

--- a/src/main/java/gov/nasa/cumulus/IConstants.java
+++ b/src/main/java/gov/nasa/cumulus/IConstants.java
@@ -8,6 +8,7 @@ public interface IConstants {
     String CNM_RESPONSE_STATUS_ATTRIBUTE_KEY = "CNM_RESPONSE_STATUS";
     String DATA_VERSION_ATTRIBUTE_KEY = "DATA_VERSION";
     String DATA_PROCESSING_TYPE = "dataProcessingType";
+    String TRACE = "trace";
     enum MessageFilterTypeEnum {
         String,
         Number

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -295,7 +295,7 @@ public class AppTest
 
 	public void testBuildMessageAttributesHash() {
 		CNMResponse cnmResponse = new CNMResponse();
-		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS");
+		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS", "forward");
 		MessageAttribute collectionBO = attributeBOMap.get(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY);
 		MessageAttribute statusBO = attributeBOMap.get(this.CNM_RESPONSE_STATUS_ATTRIBUTE_KEY);
 		MessageAttribute dataVersionBO = attributeBOMap.get(this.DATA_VERSION_ATTRIBUTE_KEY);

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -295,16 +295,26 @@ public class AppTest
 
 	public void testBuildMessageAttributesHash() {
 		CNMResponse cnmResponse = new CNMResponse();
-		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash("JASON_C1", "E","SUCCESS", "forward");
-		MessageAttribute collectionBO = attributeBOMap.get(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY);
+		Map<String, MessageAttribute> attributeBOMap =  cnmResponse.buildMessageAttributesHash(
+				"JASON_C1",
+				"E",
+				"SUCCESS",
+				"forward",
+				"NCMODIS_A-JPL-L2P-v2019.01");		MessageAttribute collectionBO = attributeBOMap.get(this.COLLECTION_SHORT_NAME_ATTRIBUTE_KEY);
 		MessageAttribute statusBO = attributeBOMap.get(this.CNM_RESPONSE_STATUS_ATTRIBUTE_KEY);
 		MessageAttribute dataVersionBO = attributeBOMap.get(this.DATA_VERSION_ATTRIBUTE_KEY);
+		MessageAttribute dataProcessingTypeBO = attributeBOMap.get(this.DATA_PROCESSING_TYPE);
+		MessageAttribute traceBO = attributeBOMap.get(this.TRACE);
 		assertEquals(MessageFilterTypeEnum.String, collectionBO.getType());
 		assertEquals("JASON_C1", collectionBO.getValue());
 		assertEquals(MessageFilterTypeEnum.String, statusBO.getType());
 		assertEquals("SUCCESS", statusBO.getValue());
 		assertEquals(MessageFilterTypeEnum.String, dataVersionBO.getType());
 		assertEquals("E", dataVersionBO.getValue());
+		assertEquals(MessageFilterTypeEnum.String, dataProcessingTypeBO.getType());
+		assertEquals("forward", dataProcessingTypeBO.getValue());
+		assertEquals(MessageFilterTypeEnum.String, traceBO.getType());
+		assertEquals("NCMODIS_A-JPL-L2P-v2019.01", traceBO.getValue());
 	}
 
 	/**
@@ -463,6 +473,150 @@ public class AppTest
 		JsonElement jelement = new JsonParser().parse(input);
 		JsonObject inputKey = jelement.getAsJsonObject();
 		String returnValue = cnmResponse.getDataProcessingType(inputKey);
+
+		assertNull(returnValue);
+	}
+
+	public void test_getTrace_success() throws  Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+
+		String input = "{\n" +
+				"    \"OriginalCNM\": {\n" +
+				"        \"version\": \"1.5\",\n" +
+				"        \"provider\": \"PODAAC\",\n" +
+				"        \"submissionTime\": \"2020-11-10T18:27:13.988143\",\n" +
+				"        \"collection\": \"MODIS_A-JPL-L2P-v2019.0\",\n" +
+				"        \"identifier\": \"5abb6308-2382-11eb-9c5b-acde48001122\",\n" +
+				"        \"trace\": \"NCMODIS_A-JPL-L2P-v2019.01\",\n" +
+				"        \"product\": {\n" +
+				"            \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0\",\n" +
+				"            \"dataVersion\": \"2019.0\",\n" +
+				"            \"dataProcessingType\": \"forward\",\n" +
+				"            \"files\": [\n" +
+				"                {\n" +
+				"                    \"type\": \"data\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"checksumType\": \"md5\",\n" +
+				"                    \"size\": 22015385.0\n" +
+				"                },\n" +
+				"                {\n" +
+				"                    \"type\": \"metadata\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"size\": 98.0\n" +
+				"                }\n" +
+				"            ]\n" +
+				"        },\n" +
+				"        \"receivedTime\": \"2022-05-23T15:17:08.347Z\"\n" +
+				"    },\n" +
+				"    \"distribution_endpoint\": \"https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/\",\n" +
+				"    \"type\": \"sns\",\n" +
+				"    \"response-endpoint\": [\n" +
+				"        \"arn:aws:sns:us-west-2:065089468788:hryeung-ia-podaac-provider-response-sns\"\n" +
+				"    ],\n" +
+				"    \"region\": \"us-west-2\",\n" +
+				"    \"WorkflowException\": \"None\"\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getTrace(inputKey);
+
+		assertEquals(returnValue, "NCMODIS_A-JPL-L2P-v2019.01");
+	}
+
+	public void test_getTrace_key_not_exist() throws  Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+
+		String input = "{\n" +
+				"    \"OriginalCNM\": {\n" +
+				"        \"version\": \"1.5\",\n" +
+				"        \"provider\": \"PODAAC\",\n" +
+				"        \"submissionTime\": \"2020-11-10T18:27:13.988143\",\n" +
+				"        \"collection\": \"MODIS_A-JPL-L2P-v2019.0\",\n" +
+				"        \"identifier\": \"5abb6308-2382-11eb-9c5b-acde48001122\",\n" +
+				"        \"product\": {\n" +
+				"            \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0\",\n" +
+				"            \"dataVersion\": \"2019.0\",\n" +
+				"            \"files\": [\n" +
+				"                {\n" +
+				"                    \"type\": \"data\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"checksumType\": \"md5\",\n" +
+				"                    \"size\": 22015385.0\n" +
+				"                },\n" +
+				"                {\n" +
+				"                    \"type\": \"metadata\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"size\": 98.0\n" +
+				"                }\n" +
+				"            ]\n" +
+				"        },\n" +
+				"        \"receivedTime\": \"2022-05-23T15:17:08.347Z\"\n" +
+				"    },\n" +
+				"    \"distribution_endpoint\": \"https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/\",\n" +
+				"    \"type\": \"sns\",\n" +
+				"    \"response-endpoint\": [\n" +
+				"        \"arn:aws:sns:us-west-2:065089468788:hryeung-ia-podaac-provider-response-sns\"\n" +
+				"    ],\n" +
+				"    \"region\": \"us-west-2\",\n" +
+				"    \"WorkflowException\": \"None\"\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getTrace(inputKey);
+
+		assertNull(returnValue);
+	}
+
+	public void test_getTrace_value_null() throws  Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+
+		String input = "{\n" +
+				"    \"OriginalCNM\": {\n" +
+				"        \"version\": \"1.5\",\n" +
+				"        \"provider\": \"PODAAC\",\n" +
+				"        \"submissionTime\": \"2020-11-10T18:27:13.988143\",\n" +
+				"        \"collection\": \"MODIS_A-JPL-L2P-v2019.0\",\n" +
+				"        \"identifier\": \"5abb6308-2382-11eb-9c5b-acde48001122\",\n" +
+				"        \"trace\": null,\n" +
+				"        \"product\": {\n" +
+				"            \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0\",\n" +
+				"            \"dataVersion\": \"2019.0\",\n" +
+				"            \"files\": [\n" +
+				"                {\n" +
+				"                    \"type\": \"data\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"checksumType\": \"md5\",\n" +
+				"                    \"size\": 22015385.0\n" +
+				"                },\n" +
+				"                {\n" +
+				"                    \"type\": \"metadata\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"size\": 98.0\n" +
+				"                }\n" +
+				"            ]\n" +
+				"        },\n" +
+				"        \"receivedTime\": \"2022-05-23T15:17:08.347Z\"\n" +
+				"    },\n" +
+				"    \"distribution_endpoint\": \"https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/\",\n" +
+				"    \"type\": \"sns\",\n" +
+				"    \"response-endpoint\": [\n" +
+				"        \"arn:aws:sns:us-west-2:065089468788:hryeung-ia-podaac-provider-response-sns\"\n" +
+				"    ],\n" +
+				"    \"region\": \"us-west-2\",\n" +
+				"    \"WorkflowException\": \"None\"\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getTrace(inputKey);
 
 		assertNull(returnValue);
 	}

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -340,4 +340,130 @@ public class AppTest
 		assertEquals(uriString,"http://distribution-uri:9000/DEV/protected-bucket/granule_id.nc");
 
 	}
+
+	public void test_getDataProcessingType_success() throws  Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+
+		String input = "{\n" +
+				"    \"OriginalCNM\": {\n" +
+				"        \"version\": \"1.5\",\n" +
+				"        \"provider\": \"PODAAC\",\n" +
+				"        \"submissionTime\": \"2020-11-10T18:27:13.988143\",\n" +
+				"        \"collection\": \"MODIS_A-JPL-L2P-v2019.0\",\n" +
+				"        \"identifier\": \"5abb6308-2382-11eb-9c5b-acde48001122\",\n" +
+				"        \"trace\": \"NCMODIS_A-JPL-L2P-v2019.01\",\n" +
+				"        \"product\": {\n" +
+				"            \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0\",\n" +
+				"            \"dataVersion\": \"2019.0\",\n" +
+				"            \"dataProcessingType\": \"forward\",\n" +
+				"            \"files\": [\n" +
+				"                {\n" +
+				"                    \"type\": \"data\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"checksumType\": \"md5\",\n" +
+				"                    \"size\": 22015385.0\n" +
+				"                },\n" +
+				"                {\n" +
+				"                    \"type\": \"metadata\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"size\": 98.0\n" +
+				"                }\n" +
+				"            ]\n" +
+				"        },\n" +
+				"        \"receivedTime\": \"2022-05-23T15:17:08.347Z\"\n" +
+				"    },\n" +
+				"    \"distribution_endpoint\": \"https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/\",\n" +
+				"    \"type\": \"sns\",\n" +
+				"    \"response-endpoint\": [\n" +
+				"        \"arn:aws:sns:us-west-2:065089468788:hryeung-ia-podaac-provider-response-sns\"\n" +
+				"    ],\n" +
+				"    \"region\": \"us-west-2\",\n" +
+				"    \"WorkflowException\": \"None\"\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getDataProcessingType(inputKey);
+
+		assertEquals(returnValue, "forward");
+	}
+
+	public void test_getDataProcessingType_null() throws  Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+
+		String input = "{\n" +
+				"    \"OriginalCNM\": {\n" +
+				"        \"version\": \"1.5\",\n" +
+				"        \"provider\": \"PODAAC\",\n" +
+				"        \"submissionTime\": \"2020-11-10T18:27:13.988143\",\n" +
+				"        \"collection\": \"MODIS_A-JPL-L2P-v2019.0\",\n" +
+				"        \"identifier\": \"5abb6308-2382-11eb-9c5b-acde48001122\",\n" +
+				"        \"trace\": \"NCMODIS_A-JPL-L2P-v2019.01\",\n" +
+				"        \"product\": {\n" +
+				"            \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0\",\n" +
+				"            \"dataVersion\": \"2019.0\",\n" +
+				"            \"files\": [\n" +
+				"                {\n" +
+				"                    \"type\": \"data\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\",\n" +
+				"                    \"checksumType\": \"md5\",\n" +
+				"                    \"size\": 22015385.0\n" +
+				"                },\n" +
+				"                {\n" +
+				"                    \"type\": \"metadata\",\n" +
+				"                    \"uri\": \"s3://podaac-dev-cumulus-test-input-v2/MODIS_A-JPL-L2P-v2019.0/2020/001/20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"name\": \"20200101232501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc.md5\",\n" +
+				"                    \"size\": 98.0\n" +
+				"                }\n" +
+				"            ]\n" +
+				"        },\n" +
+				"        \"receivedTime\": \"2022-05-23T15:17:08.347Z\"\n" +
+				"    },\n" +
+				"    \"distribution_endpoint\": \"https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/\",\n" +
+				"    \"type\": \"sns\",\n" +
+				"    \"response-endpoint\": [\n" +
+				"        \"arn:aws:sns:us-west-2:065089468788:hryeung-ia-podaac-provider-response-sns\"\n" +
+				"    ],\n" +
+				"    \"region\": \"us-west-2\",\n" +
+				"    \"WorkflowException\": \"None\"\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getDataProcessingType(inputKey);
+
+		assertNull(returnValue);
+	}
+
+	public void test_getDataProcessingType_no_product() throws  Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+
+		String input = "{\n" +
+				"    \"OriginalCNM\": {\n" +
+				"        \"version\": \"1.5\",\n" +
+				"        \"provider\": \"PODAAC\",\n" +
+				"        \"submissionTime\": \"2020-11-10T18:27:13.988143\",\n" +
+				"        \"collection\": \"MODIS_A-JPL-L2P-v2019.0\",\n" +
+				"        \"identifier\": \"5abb6308-2382-11eb-9c5b-acde48001122\",\n" +
+				"        \"trace\": \"NCMODIS_A-JPL-L2P-v2019.01\",\n" +
+				"        \"receivedTime\": \"2022-05-23T15:17:08.347Z\"\n" +
+				"    },\n" +
+				"    \"distribution_endpoint\": \"https://jh72u371y2.execute-api.us-west-2.amazonaws.com:9000/DEV/\",\n" +
+				"    \"type\": \"sns\",\n" +
+				"    \"response-endpoint\": [\n" +
+				"        \"arn:aws:sns:us-west-2:065089468788:hryeung-ia-podaac-provider-response-sns\"\n" +
+				"    ],\n" +
+				"    \"region\": \"us-west-2\",\n" +
+				"    \"WorkflowException\": \"None\"\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getDataProcessingType(inputKey);
+
+		assertNull(returnValue);
+	}
 }


### PR DESCRIPTION
# [2.1.0] 
### Added
- **PODAAC-4445 & PODAAC-4574**
  - Add in new field `dataProcessingType` in the `MessageAttributes` section for SNS topics; would only populate when field exists
- **PODAAC-4606**
  - Add in new field `trace` in the `MessageAttributes` section for SNS topics; would only populate when field exists
### Changed
### Deprecated
### Removed
### Fixed
### Security
- **PODAAC-4353**
  - Fixed Snyk warning. 
  - com.amazonaws:aws-java-sdk-core@1.12.144 to com.amazonaws:aws-java-sdk-core@1.12.209
  - com.amazonaws:amazon-kinesis-client@1.14.7 to com.amazonaws:amazon-kinesis-client@1.14.8
  - com.amazonaws:aws-java-sdk-sns@1.12.144 to com.amazonaws:aws-java-sdk-sns@1.12.209
  - com.amazonaws:aws-java-sdk-kinesis@1.12.144 to com.amazonaws:aws-java-sdk-kinesis@1.12.209
  - com.amazonaws:aws-lambda-java-core@1.1.0 to com.amazonaws:aws-lambda-java-core@1.2.1
  - com.google.code.gson:gson@2.8.9 to com.google.code.gson:gson@2.9.0