### PR TITLE
Feature/PODAAC-5921: Upgrade to Java 11 & CMA 2.0.3

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '8.0.232'
+          java-version: '11.0.6'
       - uses: gradle/gradle-build-action@v1
         with:
-          gradle-version: 4.0.1
+          gradle-version: 8.0.1
       - name: Install Python 3
         uses: actions/setup-python@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased] 
 ### Added
 ### Changed
-- **PODAAC-xxxx**
-  - Support java 17
+- **PODAAC-5921**
+  - Support java 11
   - SonarQube and Jacoco report
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased] 
 ### Added
 ### Changed
+- **PODAAC-xxxx**
+  - Support java 17
+  - SonarQube and Jacoco report
 ### Deprecated
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 ## Installation
 
-To build the Lambda code:
+To build the Lambda code, Refer to following Confluence page:
+https://wiki.jpl.nasa.gov/pages/viewpage.action?spaceKey=PD&title=SonarQube%2C+Jacoco+and+Java+17+upgrade
 
 ```shell
+* Build with sonarQube and Jacoco report
+mvn clean verify sonar:sonar \
+  -Dsonar.projectKey=cnm-response-opensource \
+  -Dsonar.projectName='cnm-response-opensource' \
+  -Dsonar.host.url=http://localhost:9000 \
+  -Dsonar.token=sqp_fc2271c4ddba6507fb38ea64d52e6912e2c6e14d
+  
+* Makde sure using java 17 and gradle 8.3
 mvn clean dependency:copy-dependencies
 gradle build
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ mvn clean verify sonar:sonar \
   -Dsonar.host.url=http://localhost:9000 \
   -Dsonar.token=sqp_fc2271c4ddba6507fb38ea64d52e6912e2c6e14d
   
-* Makde sure using java 17 and gradle 8.3
+* Make sure java 11 and gradle 8.3 are adopted.
+
 mvn clean dependency:copy-dependencies
 gradle build
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
-sourceCompatibility = 1.17
-targetCompatibility = 1.17
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
 
 dependencies {
     implementation fileTree(dir: 'target/dependency/', include: '*.jar')

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.17
+targetCompatibility = 1.17
 
 dependencies {
     implementation fileTree(dir: 'target/dependency/', include: '*.jar')
@@ -13,7 +13,7 @@ task buildZip(type: Zip) {
     into('lib') {
         from configurations.runtimeClasspath
     }
-    archiveName 'cnmResponse.zip'
+    archiveFileName.set('cnmResponse.zip')
 }
 
 build.dependsOn buildZip

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>gov.nasa.earthdata</groupId>
@@ -88,8 +88,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,84 +1,152 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>gov.nasa.cumulus</groupId>
-  <artifactId>cnm-response</artifactId>
-  <version>2.1.1-alpha.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>gov.nasa.cumulus</groupId>
+    <artifactId>cnm-response</artifactId>
+    <version>2.1.1-alpha.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>cnm-response</name>
-  <url>http://maven.apache.org</url>
+    <name>cnm-response</name>
+    <url>http://maven.apache.org</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-  <repositories>
-    <repository>
-      <id>clojars.org</id>
-      <url>https://repo.clojars.org</url>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>clojars.org</id>
+            <url>https://repo.clojars.org</url>
+        </repository>
+    </repositories>
 
-  <dependencies>
+    <dependencies>
 
-<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core -->
-<dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>aws-java-sdk-core</artifactId>
-    <version>1.12.209</version>
-</dependency>
-<!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
-<dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>amazon-kinesis-client</artifactId>
-    <version>1.14.8</version>
-</dependency>
-<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sns -->
-<dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>aws-java-sdk-sns</artifactId>
-    <version>1.12.209</version>
-</dependency>
-<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
-<dependency>
-    <groupId>com.google.code.gson</groupId>
-    <artifactId>gson</artifactId>
-    <version>2.9.0</version>
-</dependency>
-<dependency>
-  <groupId>gov.nasa.earthdata</groupId>
-  <artifactId>cumulus-message-adapter</artifactId>
-  <version>1.3.9</version>
-</dependency>
-<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-kinesis -->
-<dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>aws-java-sdk-kinesis</artifactId>
-    <version>1.12.209</version>
-</dependency>
-<dependency>
-    <groupId>commons-io</groupId>
-    <artifactId>commons-io</artifactId>
-    <version>2.11.0</version>
-</dependency>
-<dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>aws-lambda-java-core</artifactId>
-    <version>1.2.1</version>
-</dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.12.565</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-kinesis-->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
+            <version>1.12.565</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-kinesis-client</artifactId>
+            <version>1.15.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sns-->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <version>1.12.565</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>gov.nasa.earthdata</groupId>
+            <artifactId>cumulus-message-adapter</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.6.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.wordinator.xml2docx.MakeDocx</mainClass>
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <formats>
+                                <format>XML</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.10.0.2594</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Support PODAAC-5921, upgrade to CMA 2.0.3

Ticket: [PODAAC-5921]

### Description

make CNMResponse cumulus 16 and CMA 2.0.3 compatible.

### Overview of work done

Upgrade to make use of CMA 2.0.3
Java 11
dependency cumulus-message-adapter 1.3.9 -> 2.0.0


### Overview of verification done

Download the github action build artifact, un-zip and use 

javap -verbose CNMResponse.class 
to verify the compiled class file is at version 55, which is java11.

Integration testing with MetadataAggregator and CNMResponse

#### Tested in SIT:

_Explain how you tested in SIT, if applicable_

## PR checklist:

* [ ] Linted
* [] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated

_See [Pull Request Review Checklist](https://wiki.earthdata.nasa.gov/display/PCESA/Pull+Request+Review+Checklist) for pointers on reviewing this pull request_
