### PR TITLE
Add support for Kinesis ARNs

### DIFF
--- a/src/main/java/gov/nasa/cumulus/KinesisSender.java
+++ b/src/main/java/gov/nasa/cumulus/KinesisSender.java
@@ -33,7 +33,13 @@ public class KinesisSender extends Sender {
             return;
         }
         PutRecordRequest putRecord = new PutRecordRequest();
-        putRecord.setStreamName(endpoint);
+
+        if (endpoint.startsWith("arn:aws:kinesis:")) {
+            putRecord.setStreamARN(endpoint);
+        } else {
+            putRecord.setStreamName(endpoint);
+        }
+
         putRecord.setPartitionKey("1");
         putRecord.setData(ByteBuffer.wrap(bytes));
         this.kinesisClient.putRecord(putRecord);


### PR DESCRIPTION
The current version of cumulus-cnm-response-task only supports Kinesis stream names when specifying a Kinesis endpoint. In order to send responses to external providers, it is necessary to specify the endpoint as a Kinesis stream ARN.