### PR TITLE
[PODAAC-7071) Address issue where collection returns "Unknown/Missing" for 1.6.1 CNM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- **PODAAC-7071**
+  - Updated getCollection to address CNM 1.6.1 missing collection issue (issues/232)
 ### Security
 
 # [3.1.0] 

--- a/src/main/java/gov/nasa/cumulus/CNMResponse.java
+++ b/src/main/java/gov/nasa/cumulus/CNMResponse.java
@@ -305,7 +305,8 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      * by the 'buildMessageAttributesHash' method.
      * <br><br>
      * First try to use the OriginalCNM > collection field
-     * Next checks input > collection
+     * Next tries to use OriginalCNM > collection > name (cnm 1.6.1)
+     * Finally checks input > collection
      * If neither is available, then returns a generic error string
      *<br><br>
      * @param input     the raw input to PerformFunction, as JsonObject
@@ -313,13 +314,29 @@ public class CNMResponse implements ITask, IConstants, RequestHandler<String, St
      */
     public String getCollection(JsonObject input) {
         try {
-            return input.getAsJsonObject("config")
+            JsonElement collection = input.getAsJsonObject("config")
                     .getAsJsonObject("OriginalCNM")
-                    .get("collection").getAsString();
+                    .get("collection");
+
+            if (collection.isJsonPrimitive()){
+                /* For CNM <= 1.6.0
+                "collection": "COLLECTION_NAME"
+                 */
+                return collection.getAsString();
+            } else {
+                /* For CNM = 1.6.1
+                "collection": {
+                    "name": "COLLECTION_NAME",
+                    "version": "COLLECTION_VERSION"
+                }
+                */
+                return collection.getAsJsonObject().get("name").getAsString();
+            }
         } catch (Exception e) {
             if (input.getAsJsonObject("input").has("collection")) {
                 return input.getAsJsonObject("input").get("collection").getAsString();
             } else {
+                AdapterLogger.LogError(this.className + ".getCollection cannot find collection.\n" + e.getMessage());
                 return "Unknown/Missing";
             }
         }

--- a/src/test/java/gov/nasa/cumulus/AppTest.java
+++ b/src/test/java/gov/nasa/cumulus/AppTest.java
@@ -620,4 +620,45 @@ public class AppTest
 
 		assertNull(returnValue);
 	}
+
+	public void test_getCollection_1_6_0() throws Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+		String input = "{\n" +
+				"    \"config\": {\n" +
+				"        \"OriginalCNM\": {\n" +
+				"            \"version\": \"1.6.0\",\n" +
+				"            \"provider\": \"JPL\",\n" +
+				"			 \"collection\": \"JASON_CS_S6A_L2_ALT_LR_RED_OST_NTC_F08_UNVALIDATED\"\n" +
+				"        }\n" +
+				"    }\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getCollection(inputKey);
+
+		assertEquals("JASON_CS_S6A_L2_ALT_LR_RED_OST_NTC_F08_UNVALIDATED", returnValue);
+	}
+
+	public void test_getCollection_1_6_1() throws Exception{
+		CNMResponse cnmResponse = new CNMResponse();
+		String input = "{\n" +
+				"    \"config\": {\n" +
+				"        \"OriginalCNM\": {\n" +
+				"            \"version\": \"1.6.1\",\n" +
+				"            \"provider\": \"JPL\",\n" +
+				"            \"collection\": {\n" +
+				"                \"name\": \"JASON_CS_S6A_L2_ALT_LR_RED_OST_NTC_F08_UNVALIDATED\",\n" +
+				"                \"version\": \"F08\"\n" +
+				"            }\n" +
+				"        }\n" +
+				"    }\n" +
+				"}";
+
+		JsonElement jelement = new JsonParser().parse(input);
+		JsonObject inputKey = jelement.getAsJsonObject();
+		String returnValue = cnmResponse.getCollection(inputKey);
+
+		assertEquals("JASON_CS_S6A_L2_ALT_LR_RED_OST_NTC_F08_UNVALIDATED", returnValue);
+	}
 }


### PR DESCRIPTION
When CNM 1.6.1 is being ingested, the collection format is slightly different this CNM Response wasn't able to handle it and returns `Unknown/Missing` for the collection

This PR repairs said issue by determining whether the collection is part of json and needs to dig in for `name` or just a string

This PR is to fix this issue: https://github.com/podaac/cumulus-cnm-response-task/issues/232